### PR TITLE
30MM rearm bug

### DIFF
--- a/@AH-64D Apache Longbow/Addons/fza_ah64_controls/scripting/functions/damage/fn_damageM230.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_controls/scripting/functions/damage/fn_damageM230.sqf
@@ -87,7 +87,6 @@ _rand = random _heatfactor;
 
 if (_rand > _heatchance) then {
     ["fza_ah64_bt_gun", 0.5, "fza_ah64_bt_jammed", 1] spawn fza_fnc_playAudio;
-    _heli setHit ["otochlaven", 0.9];
-    _heli removemagazine "fza_m230_1200";
-    _heli removemagazine "fza_m230_300";
+    _heli setAmmo ["fza_m230", 0];
+    fza_ah64_gunheat = 100;
 };

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_controls/scripting/functions/damage/fn_damageSystem.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_controls/scripting/functions/damage/fn_damageSystem.sqf
@@ -61,8 +61,7 @@ if (_system == "pnvs") then {
 if (_system == "otocvez") then {
     if (_usesound && _oldDam < 0.8 && _damage >= 0.8) then {
         ["fza_ah64_bt_gun", 0.5, "fza_ah64_bt_actuator", 1, "fza_ah64_bt_failure", 1] spawn fza_fnc_playAudio;
-        _heli removemagazine "fza_m230_1200";
-        _heli removemagazine "fza_m230_300";
+        _heli setAmmo ["fza_m230", 0];
     };
 };
 


### PR DESCRIPTION
A bug that plagues mainly ace rearms setting of rearming based on magazine size
the bug was caused by the removal of the magazine meaning there was no magazine to rearm
