### PR TITLE
Hellfire Stability

### DIFF
--- a/@AH-64D Apache Longbow/Addons/fza_ah64_controls/config/CfgAmmo.hpp
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_controls/config/CfgAmmo.hpp
@@ -110,8 +110,8 @@ class CfgAmmo
 		fuseDistance				= 100;
 		manualControl 				= 0;
 		maxControlRange				= 8000;
-		trackOversteer				= 4;
-		trackLead					= 1.2;
+		trackOversteer				= 1;
+		trackLead					= 1;
 		maneuvrability				= 21;
 		timeToLive					= 70;
 		cmImmunity					= 0.97;


### PR DESCRIPTION
the issue was trackoversteer and tracklead are 0-1 value, going over that value makes them work exceptional in singleplayer but breaks down in multiplayer
test on speeding cars up to 150KPH
#88 