### PR TITLE
Fire Extinguisher Replaceable

### DIFF
--- a/@AH-64D Apache Longbow/Addons/fza_ah64_controls/config/CfgAmmo.hpp
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_controls/config/CfgAmmo.hpp
@@ -45,9 +45,8 @@ class CfgAmmo
 	{
 		lockType					=2;
 	};
-	class fza_fireBottleSecondary: Default
+	class fza_fireBottleSecondary: fza_fireBottlePrimary
 	{
-		lockType					=2;
 	};
 	
 	///////////////////////////////////////////////////////////////////////

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_controls/config/CfgAmmo.hpp
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_controls/config/CfgAmmo.hpp
@@ -41,6 +41,14 @@ class CfgAmmo
 		weaponLockSystem			=0;
 		lockType					=2;
 	};
+	class fza_fireBottlePrimary: Default
+	{
+		lockType					=2;
+	};
+	class fza_fireBottleSecondary: Default
+	{
+		lockType					=2;
+	};
 	
 	///////////////////////////////////////////////////////////////////////
 	//////////////////////////////M230/////////////////////////////////////

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_controls/config/CfgFunctions.hpp
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_controls/config/CfgFunctions.hpp
@@ -83,6 +83,7 @@ class CfgFunctions
 		{
 			file = "\fza_ah64_controls\scripting\functions\fire";
 			class fireHandleControl {R;};
+			class fireHandleRearm {R;};
 		};
 		class fx {
 			file = "\fza_ah64_controls\scripting\functions\fx";

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_controls/config/CfgMagazines.hpp
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_controls/config/CfgMagazines.hpp
@@ -33,6 +33,20 @@ class CfgMagazines
 		tracersEvery=0;
 		nameSound="";
 	};
+	class fza_Fb1: VehicleMagazine
+	{
+		scope = 1;
+		displayName="Primary Fire Bottle";
+		ammo="fza_fireBottlePrimary";
+		count=1;
+	};
+	class fza_Fb2: VehicleMagazine
+	{
+		scope = 1;
+		displayName="Reserve Fire Bottle";
+		ammo="fza_fireBottleSecondary";
+		count=1;
+	};
 	
 	////////////////////////////////////////////////////////////////////////
 	///////////////////////////////M230/////////////////////////////////////

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_controls/config/CfgMagazines.hpp
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_controls/config/CfgMagazines.hpp
@@ -40,12 +40,10 @@ class CfgMagazines
 		ammo="fza_fireBottlePrimary";
 		count=1;
 	};
-	class fza_Fb2: VehicleMagazine
+	class fza_Fb2: fza_Fb1
 	{
-		scope = 1;
 		displayName="Reserve Fire Bottle";
 		ammo="fza_fireBottleSecondary";
-		count=1;
 	};
 	
 	////////////////////////////////////////////////////////////////////////

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_controls/config/CfgWeapons.hpp
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_controls/config/CfgWeapons.hpp
@@ -120,6 +120,16 @@ class CfgWeapons
 		cursorAim="";
 		magazines[]={"fza_safe"};
 	};
+	class fza_Fx1: fza_m230
+	{
+		showToPlayer = 0;
+		magazines[]={"fza_Fb1"};
+	};	
+	class fza_Fx2: fza_m230
+	{
+		showToPlayer = 0;
+		magazines[]={"fza_Fb2"};
+	};	
 
 	///////////////////////////////////////////////////////////////////////
 	//////////////////////////////HELLFIRE/////////////////////////////////

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_controls/config/CfgWeapons.hpp
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_controls/config/CfgWeapons.hpp
@@ -125,9 +125,8 @@ class CfgWeapons
 		showToPlayer = 0;
 		magazines[]={"fza_Fb1"};
 	};	
-	class fza_Fx2: fza_m230
+	class fza_Fx2: fza_Fx1
 	{
-		showToPlayer = 0;
 		magazines[]={"fza_Fb2"};
 	};	
 

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_controls/config/cfgVehicles.hpp
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_controls/config/cfgVehicles.hpp
@@ -1119,8 +1119,8 @@ class CfgVehicles
 				primary = 1;
 				primaryGunner = 1;
 				stabilizedInAxes = 3;
-				weapons[] = {"fza_ma_safe", "Laserdesignator_mounted", "fza_burstlimiter","fza_m230"};
-				magazines[] = {"fza_safe", "LaserBatteries", "fza_m230_1200"};
+				weapons[] = {"fza_ma_safe", "fza_Fx1", "fza_Fx2", "Laserdesignator_mounted", "fza_burstlimiter","fza_m230"};
+				magazines[] = {"fza_safe", "fza_Fb1", "fza_Fb2", "LaserBatteries", "fza_m230_1200"};
 				memoryPointsGetInGunner = "pos gunner";
 			    memoryPointsGetInGunnerDir = "pos gunner dir";
 			    memoryPointGun = "laserBegin";

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_controls/scripting/XEH_preInit.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_controls/scripting/XEH_preInit.sqf
@@ -100,7 +100,7 @@ fza_ah64_Cscopelist = [];
 fza_ah64_hducolor = [0.1, 1, 0, 1];
 fza_ah64_schedarray = [fza_fnc_weaponTurretAim, fza_fnc_targetingPNVSControl, fza_fnc_targetingSched, fza_fnc_avionicsSlipIndicator, fza_fnc_navigationWaypointEta, fza_fnc_ihadssDraw, fza_fnc_targetingUpdate, fza_fnc_engineGovernor, fza_fnc_mpdUpdateDisplays, fza_fnc_sfmplusUpdate];
 fza_ah64_introShownThisScenario = false;
-fza_ah64_slowschedarray = [fza_fnc_targetingUpdate, fza_fnc_weaponPylonCheckValid];
+fza_ah64_slowschedarray = [fza_fnc_targetingUpdate, fza_fnc_weaponPylonCheckValid, fza_fnc_fireHandleRearm];
 fza_ah64_mapfaker = addMissionEventHandler["Draw3d", {
 	[0] call fza_fnc_coreScheduler;
 }];

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_controls/scripting/damage/enginefire.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_controls/scripting/damage/enginefire.sqf
@@ -12,8 +12,8 @@ if (player == driver _heli || player == gunner _heli) then {
 };
 
 _helidamage = 0;
-_firepstate = !(_heli getVariable "fza_ah64_firepdisch");
-_firerstate = !(_heli getVariable "fza_ah64_firerdisch");
+_firepstate = _heli ammo "fza_Fx1";
+_firerstate = _heli ammo "fza_Fx2";
 
 _side = [];
 _sidef = [];
@@ -79,11 +79,11 @@ while {
 }
 do {
     _rand = random 10;
-    _firepon = _heli getVariable "fza_ah64_firepdisch";
-    _fireron = _heli getVariable "fza_ah64_firerdisch";
-    if (_eng == "left" && _heli getVariable "fza_ah64_fire1arm" == 1 && ((_firepon && _firepstate) || (_fireron && _firerstate))) exitwith {};
-    if (_eng == "right" && _heli getVariable "fza_ah64_fire2arm" == 1 && ((_firepon && _firepstate) || (_fireron && _firerstate))) exitwith {};
-    if (_eng == "apu" && _heli getVariable "fza_ah64_fireapuarm" == 1 && ((_firepon && _firepstate) || (_fireron && _firerstate))) exitwith {};
+    _firepon = _heli ammo "fza_Fx1";
+    _fireron = _heli ammo "fza_Fx2";
+    if (_eng == "left" && _heli getVariable "fza_ah64_fire1arm" == 1 && ((_firepon == 0 && _firepstate == 1) || (_fireron == 0 && _firerstate == 1))) exitwith {};
+    if (_eng == "right" && _heli getVariable "fza_ah64_fire2arm" == 1 && ((_firepon == 0 && _firepstate == 1) || (_fireron == 0 && _firerstate == 1))) exitwith {};
+    if (_eng == "apu" && _heli getVariable "fza_ah64_fireapuarm" == 1 && ((_firepon == 0 && _firepstate == 1) || (_fireron == 0 && _firerstate == 1))) exitwith {};
 
     if (_rand > 9.9 && !(isengineon _heli)) exitwith {};
     _helidamage = _helidamage + 0.0005;

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_controls/scripting/functions/damage/fn_damageSystem.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_controls/scripting/functions/damage/fn_damageSystem.sqf
@@ -124,10 +124,6 @@ if (_system == "leng") then {
 };
 
 if (_system == "reng") then {
-    if (_damage == 0 && _oldDam != 0) then {
-        _heli setVariable ["fza_ah64_firerdisch", false, true];
-        _heli setVariable ["fza_ah64_e2_fire", false, true];
-    };
     if (_damage >= 0.4) then {
         [_heli, "right"] execvm "\fza_ah64_controls\scripting\damage\enginefire.sqf";
     };

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_controls/scripting/functions/damage/fn_damageSystem.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_controls/scripting/functions/damage/fn_damageSystem.sqf
@@ -118,10 +118,6 @@ if (_system == "cockpit") then {
 };
 
 if (_system == "leng") then {
-    if (_damage == 0 && _oldDam != 0) then {
-        _heli setVariable ["fza_ah64_firepdisch", false, true];
-        _heli setVariable ["fza_ah64_e1_fire", false, true];
-    };
     if (_damage >= 0.4) then {
         [_heli, "left"] execvm "\fza_ah64_controls\scripting\damage\enginefire.sqf";
     };

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_controls/scripting/functions/event/fn_eventInit.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_controls/scripting/functions/event/fn_eventInit.sqf
@@ -55,8 +55,6 @@ if (!(_heli getVariable ["fza_ah64_aircraftInitialised", false]) && local _heli)
     _heli setVariable ["fza_ah64_apu_fire", false, true];
     _heli setVariable ["fza_ah64_e1_fire", false, true];
     _heli setVariable ["fza_ah64_e2_fire", false, true];
-    _heli setVariable ["fza_ah64_firepdisch", false, true];
-    _heli setVariable ["fza_ah64_firerdisch", false, true];
     _heli setVariable ["fza_ah64_irjstate", 0, true];
     _heli setVariable ["fza_ah64_rfjstate", 0, true];
     _heli setVariable ["fza_ah64_irjon", 0, true];

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_controls/scripting/functions/event/fn_eventInit.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_controls/scripting/functions/event/fn_eventInit.sqf
@@ -55,6 +55,8 @@ if (!(_heli getVariable ["fza_ah64_aircraftInitialised", false]) && local _heli)
     _heli setVariable ["fza_ah64_apu_fire", false, true];
     _heli setVariable ["fza_ah64_e1_fire", false, true];
     _heli setVariable ["fza_ah64_e2_fire", false, true];
+    _heli setVariable ["fza_ah64_firepdisch", false, true];
+    _heli setVariable ["fza_ah64_firerdisch", false, true];
     _heli setVariable ["fza_ah64_irjstate", 0, true];
     _heli setVariable ["fza_ah64_rfjstate", 0, true];
     _heli setVariable ["fza_ah64_irjon", 0, true];

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_controls/scripting/functions/fire/fn_fireHandleControl.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_controls/scripting/functions/fire/fn_fireHandleControl.sqf
@@ -129,6 +129,7 @@ switch(_control) do {
 	case "fbp": {
 		if ((_heli getVariable "fza_ah64_fireapuarm" == 1 || _heli getVariable "fza_ah64_fire2arm" == 1 || _heli getVariable "fza_ah64_fire1arm" == 1) && (_heli ammo "fza_Fx1" == 1)) then {
 				_heli setobjecttexture [SEL_IN_LT_FIREPDIS, "\fza_ah64_us\tex\in\pushbut.paa"];
+				_heli setVariable ["fza_ah64_firepdisch", true, true];
 				_heli setAmmo ["fza_fx1", 0];
 			};
 			["fza_ah64_button_click2", 0.1];
@@ -136,6 +137,7 @@ switch(_control) do {
 		case "fbr": {
 			if ((_heli getVariable "fza_ah64_fireapuarm" == 1 || _heli getVariable "fza_ah64_fire2arm" == 1 || _heli getVariable "fza_ah64_fire1arm" == 1) && (_heli ammo "fza_Fx2" == 1)) then {
 				_heli setobjecttexture [SEL_IN_LT_FIRERDIS, "\fza_ah64_us\tex\in\pushbut.paa"];
+				_heli setVariable ["fza_ah64_firerdisch", true, true];
 				_heli setAmmo ["fza_fx2", 0];
 			};
 			["fza_ah64_button_click2", 0.1];

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_controls/scripting/functions/fire/fn_fireHandleControl.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_controls/scripting/functions/fire/fn_fireHandleControl.sqf
@@ -73,10 +73,10 @@ switch(_control) do {
 			_heli setobjecttexture [SEL_IN_LT_FIREAPU, ""];
 			_heli setobjecttexture [SEL_IN_LT_MSTRCAU, ""];
 			_heli setobjecttexture [SEL_IN_LT_MSTRWRN, ""];
-			if !(_heli getVariable "fza_ah64_firepdisch") then {
+			if (_heli ammo "fza_Fx1" == 1) then {
 				_heli setobjecttexture [SEL_IN_LT_FIREPDIS, ""];
 			};
-			if !(_heli getVariable "fza_ah64_firerdisch") then {
+			if (_heli ammo "fza_Fx2" == 1) then {
 				_heli setobjecttexture [SEL_IN_LT_FIRERDIS, ""];
 			};
 			fza_ah64_firetest = 0;
@@ -127,16 +127,16 @@ switch(_control) do {
 			};
 	};
 	case "fbp": {
-		if ((_heli getVariable "fza_ah64_fireapuarm" == 1 || _heli getVariable "fza_ah64_fire2arm" == 1 || _heli getVariable "fza_ah64_fire1arm" == 1) && !(_heli getVariable "fza_ah64_firepdisch")) then {
+		if ((_heli getVariable "fza_ah64_fireapuarm" == 1 || _heli getVariable "fza_ah64_fire2arm" == 1 || _heli getVariable "fza_ah64_fire1arm" == 1) && (_heli ammo "fza_Fx1" == 1)) then {
 				_heli setobjecttexture [SEL_IN_LT_FIREPDIS, "\fza_ah64_us\tex\in\pushbut.paa"];
-				_heli setVariable ["fza_ah64_firepdisch", true, true];
+				_heli setAmmo ["fza_fx1", 0];
 			};
 			["fza_ah64_button_click2", 0.1];
 		};
 		case "fbr": {
-			if ((_heli getVariable "fza_ah64_fireapuarm" == 1 || _heli getVariable "fza_ah64_fire2arm" == 1 || _heli getVariable "fza_ah64_fire1arm" == 1) && !(_heli getVariable "fza_ah64_firerdisch")) then {
+			if ((_heli getVariable "fza_ah64_fireapuarm" == 1 || _heli getVariable "fza_ah64_fire2arm" == 1 || _heli getVariable "fza_ah64_fire1arm" == 1) && (_heli ammo "fza_Fx2" == 1)) then {
 				_heli setobjecttexture [SEL_IN_LT_FIRERDIS, "\fza_ah64_us\tex\in\pushbut.paa"];
-				_heli setVariable ["fza_ah64_firerdisch", true, true];
+				_heli setAmmo ["fza_fx2", 0];
 			};
 			["fza_ah64_button_click2", 0.1];
 		};
@@ -186,10 +186,10 @@ switch(_control) do {
 			_heli setobjecttexture [SEL_IN_LT_FIREAPU, ""];
 			_heli setobjecttexture [SEL_IN_LT_MSTRCAU, ""];
 			_heli setobjecttexture [SEL_IN_LT_MSTRWRN, ""];
-			if !(_heli getVariable "fza_ah64_firepdisch") then {
+			if (_heli ammo "fza_Fx1" == 1) then {
 				_heli setobjecttexture [SEL_IN_LT_FIREPDIS, ""];
 			};
-			if !(_heli getVariable "fza_ah64_firerdisch") then {
+			if (_heli ammo "fza_Fx2" == 1) then {
 				_heli setobjecttexture [SEL_IN_LT_FIRERDIS, ""];
 			};
 			fza_ah64_firetest = 0;

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_controls/scripting/functions/fire/fn_fireHandleRearm.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_controls/scripting/functions/fire/fn_fireHandleRearm.sqf
@@ -20,7 +20,6 @@ Author:
 params ["_heli"];
 
 if ((_heli ammo "fza_Fx1" == 1) && (_heli getVariable "fza_ah64_firepdisch" == true)) then {
-    _heli setobjecttexture [SEL_IN_LT_FIREPDIS, ""];
     _heli setVariable ["fza_ah64_firepdisch", false, true];
     _heli setVariable ["fza_ah64_fire1arm", 0];
 	_heli setobjecttexture [SEL_IN_LT_FIRE1RDY, ""];
@@ -30,7 +29,6 @@ if ((_heli ammo "fza_Fx1" == 1) && (_heli getVariable "fza_ah64_firepdisch" == t
 	_heli setobjecttexture [SEL_IN_LT_FIREAPURDY, ""];
 };
 if ((_heli ammo "fza_Fx2" == 1) && (_heli getVariable "fza_ah64_firerdisch" == true)) then {
-    _heli setobjecttexture [SEL_IN_LT_FIRERDIS, ""];
     _heli setVariable ["fza_ah64_firerdisch", false, true];
     _heli setVariable ["fza_ah64_fire1arm", 0];
 	_heli setobjecttexture [SEL_IN_LT_FIRE1RDY, ""];

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_controls/scripting/functions/fire/fn_fireHandleRearm.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_controls/scripting/functions/fire/fn_fireHandleRearm.sqf
@@ -1,0 +1,41 @@
+/* ----------------------------------------------------------------------------
+Function: fza_fnc_fireHandleRearm
+
+Description:
+    Handles the reset of fire system when rearming
+
+Parameters:
+	_heli - The helicopter to act on
+
+Returns:
+
+Examples:
+    [_heli] call fireHandleRearm
+    
+Author:
+	Rosd6(Dryden)
+---------------------------------------------------------------------------- */
+#include "\fza_ah64_controls\headers\script_common.hpp"
+#include "\fza_ah64_controls\headers\selections.h"
+params ["_heli"];
+
+if ((_heli ammo "fza_Fx1" == 1) && (_heli getVariable "fza_ah64_firepdisch" == true)) then {
+    _heli setobjecttexture [SEL_IN_LT_FIREPDIS, ""];
+    _heli setVariable ["fza_ah64_firepdisch", false, true];
+    _heli setVariable ["fza_ah64_fire1arm", 0];
+	_heli setobjecttexture [SEL_IN_LT_FIRE1RDY, ""];
+    _heli setVariable ["fza_ah64_fire2arm", 0];
+	_heli setobjecttexture [SEL_IN_LT_FIRE2RDY, ""];
+    _heli setVariable ["fza_ah64_fireapuarm", 0];
+	_heli setobjecttexture [SEL_IN_LT_FIREAPURDY, ""];
+};
+if ((_heli ammo "fza_Fx2" == 1) && (_heli getVariable "fza_ah64_firerdisch" == true)) then {
+    _heli setobjecttexture [SEL_IN_LT_FIRERDIS, ""];
+    _heli setVariable ["fza_ah64_firerdisch", false, true];
+    _heli setVariable ["fza_ah64_fire1arm", 0];
+	_heli setobjecttexture [SEL_IN_LT_FIRE1RDY, ""];
+    _heli setVariable ["fza_ah64_fire2arm", 0];
+	_heli setobjecttexture [SEL_IN_LT_FIRE2RDY, ""];
+    _heli setVariable ["fza_ah64_fireapuarm", 0];
+	_heli setobjecttexture [SEL_IN_LT_FIREAPURDY, ""];
+};

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_controls/scripting/functions/mpd/fn_Ufd.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_controls/scripting/functions/mpd/fn_Ufd.sqf
@@ -108,10 +108,10 @@ do {
     } else {
         _heli setobjecttexture [SEL_IN_LT_FIREAPU, ""];
     };
-    if (_heli getVariable "fza_ah64_firepdisch") then {
+	if (_heli ammo "fza_Fx1" == 0) then {
         _heli setobjecttexture [SEL_IN_LT_FIREPDIS, "\fza_ah64_us\tex\in\pushbut.paa"];
     };
-    if (_heli getVariable "fza_ah64_firerdisch") then {
+	if (_heli ammo "fza_Fx2" == 0) then {
         _heli setobjecttexture [SEL_IN_LT_FIRERDIS, "\fza_ah64_us\tex\in\pushbut.paa"];
     };
 

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_controls/scripting/functions/mpd/fn_Ufd.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_controls/scripting/functions/mpd/fn_Ufd.sqf
@@ -110,9 +110,13 @@ do {
     };
 	if (_heli ammo "fza_Fx1" == 0) then {
         _heli setobjecttexture [SEL_IN_LT_FIREPDIS, "\fza_ah64_us\tex\in\pushbut.paa"];
+    } else {
+        _heli setobjecttexture [SEL_IN_LT_FIREPDIS, ""];
     };
 	if (_heli ammo "fza_Fx2" == 0) then {
         _heli setobjecttexture [SEL_IN_LT_FIRERDIS, "\fza_ah64_us\tex\in\pushbut.paa"];
+    } else {
+        _heli setobjecttexture [SEL_IN_LT_FIRERDIS, ""];
     };
 
     ///EWCA//


### PR DESCRIPTION
Turns the fire extinguisher variable into an 2 ammo counts primary & secondary
using these allows for vanilla, ace, Zeus rearm of the fire bottles through any rearming method