### PR TITLE
ACE LASER Hellfire Cfg And Keybind (Waiting on MPD Update)

### DIFF
--- a/@AH-64D Apache Longbow/Addons/fza_ah64_controls/config/CfgAmmo.hpp
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_controls/config/CfgAmmo.hpp
@@ -5,12 +5,8 @@ class CfgAmmo
 	class Bulletbase;
 	class MissileCore;
 	class MissileBase;
-	class Missile_AGM_02_F : MissileBase {
-		class Components;
-		class EventHandlers;
-	};
-	class RocketCore;
-	class RocketBase;
+	class Missile_AA_04_F;
+	class M_Scalpel_AT;
 	class GrenadeBase;
 	class FlareCore;
 	class B_9x21_Ball;
@@ -117,7 +113,9 @@ class CfgAmmo
 	///////////////////////////////////////////////////////////////////////
 	//////////////////////////////HELLFIRE/////////////////////////////////
 	///////////////////////////////////////////////////////////////////////	
-	class fza_agm114base : Missile_AGM_02_F {
+
+	class ACE_Hellfire_AGM114K: M_Scalpel_AT {class ace_missileguidance;};
+	class fza_agm114base : ACE_Hellfire_AGM114K {
 
 		ace_frag_enabled 			= 0;
 		ace_frag_skip 				= 1;
@@ -177,26 +175,13 @@ class CfgAmmo
 		weaponLockSystem			= "4 + 8";
 		maneuvDependsOnSpeedCoef	= 0.018;
 
-		flightProfiles[]	= {TopDown,LoalDistance,Cruise};
-		class Direct{};
-		class TopDown
-		{
-			ascendAngle				= 39;
-			ascendHeight			= 360;
-			minDistance				= 600;
-			descendDistance			= 700;
-		};
+		flightProfiles[]	= {LoalDistance};
 		class LoalDistance
 		{
 			lockSeekDistanceFromParent = 500;
 		};
-		class Cruise
-		{
-			preferredFlightAltitude = 500;
-			lockDistanceToTarget = 1000;
-		};
 
-		class Components : Components
+		class Components
 		{
 			class SensorsManagerComponent
 			{
@@ -228,13 +213,68 @@ class CfgAmmo
 				};
 			};
 		};
-		class Eventhandlers: Eventhandlers
+		class Eventhandlers
 		{
 			class FZA_EH
 			{
 				fired = "_this call fza_fnc_weaponMissileSlowDown";
 			};
 		};
+		class CamShakeExplode
+		{
+			power = 22;
+			duration = 2;
+			frequency = 20;
+			distance = 163.905;
+		};
+		class CamShakeHit
+		{
+			power = 110;
+			duration = 0.6;
+			frequency = 20;
+			distance = 1;
+		};
+		class CamShakeFire
+		{
+			power = 2.9907;
+			duration = 1.8;
+			frequency = 20;
+			distance = 71.5542;
+		};
+		class CamShakePlayerFire
+		{
+			power = 4;
+			duration = 0.1;
+			frequency = 20;
+			distance = 1;
+		};
+        class ace_missileguidance {
+            enabled = 1;
+
+            minDeflection = 0.0005;      // Minium flap deflection for guidance
+            maxDeflection = 0.01;       // Maximum flap deflection for guidance
+            incDeflection = 0.0005;      // The incrmeent in which deflection adjusts.
+
+            canVanillaLock = 0;          // Can this default vanilla lock? Only applicable to non-cadet mode
+
+            // Guidance type for munitions
+            defaultSeekerType = "SALH";
+            seekerTypes[] = { "SALH", "LIDAR", "SARH", "Optic", "Thermal", "GPS", "SACLOS", "MCLOS" };
+
+            defaultSeekerLockMode = "LOAL";
+            seekerLockModes[] = { "LOAL" };
+
+            seekLastTargetPos = 1;      // seek last target position [if seeker loses LOS of target, continue to last known pos]
+            seekerAngle = 90;           // Angle in front of the missile which can be searched
+            seekerAccuracy = 1;         // seeker accuracy multiplier
+
+            seekerMinRange = 1;
+            seekerMaxRange = 8000;      // Range from the missile which the seeker can visually search
+
+            // Attack profile type selection
+            defaultAttackProfile = "hellfire";
+            attackProfiles[] = {"hellfire", "hellfire_hi", "hellfire_lo"};
+        };
 	};
 	class fza_agm114l : fza_agm114base
 	{
@@ -259,14 +299,53 @@ class CfgAmmo
 		activeSensorAlwaysOn = 0;
 		missileLockCone				= 90;
 		missileKeepLockedCone		= 90;
+
 		flightProfiles[]	= {TopDown,LoalDistance,Cruise};
+		class Direct{};
 		class TopDown
 		{
-			ascendAngle				= 26.5;
-			ascendHeight			= 850;
-			minDistance				= 1000;
-			descendDistance			= 1200;
+			ascendAngle				= 39;
+			ascendHeight			= 360;
+			minDistance				= 600;
+			descendDistance			= 700;
 		};
+		class LoalDistance
+		{
+			lockSeekDistanceFromParent = 500;
+		};
+		class Cruise
+		{
+			preferredFlightAltitude = 500;
+			lockDistanceToTarget = 1000;
+		};
+        class ace_missileguidance {
+            enabled = 1;
+
+            minDeflection = 0;      // Minium flap deflection for guidance
+            maxDeflection = 0;       // Maximum flap deflection for guidance
+            incDeflection = 0;      // The incrmeent in which deflection adjusts.
+
+            canVanillaLock = 0;          // Can this default vanilla lock? Only applicable to non-cadet mode
+
+            // Guidance type for munitions
+            defaultSeekerType = "";
+            seekerTypes[] = { "" };
+
+            defaultSeekerLockMode = "";
+            seekerLockModes[] = { "" };
+
+            seekLastTargetPos = 0;      // seek last target position [if seeker loses LOS of target, continue to last known pos]
+            seekerAngle = 0;           // Angle in front of the missile which can be searched
+            seekerAccuracy = 0;         // seeker accuracy multiplier
+
+            seekerMinRange = 0;
+            seekerMaxRange = 0;      // Range from the missile which the seeker can visually search
+
+            // Attack profile type selection
+            defaultAttackProfile = "";
+            attackProfiles[] = {""};
+        };
+
 	};
 	class fza_agm114k : fza_agm114base
 	{
@@ -296,7 +375,7 @@ class CfgAmmo
 		missileManualControlCone 	= 90;
 		weaponLockSystem 			= "4";
 		weaponType					= "missileAT";
-		class Components : Components
+		class Components
 		{
 			class SensorsManagerComponent
 			{
@@ -305,12 +384,12 @@ class CfgAmmo
 					class LaserSensorComponent : SensorTemplateLaser
 					{
 						class AirTarget {
-							minRange = 7000;
-							maxRange = 7000;
+							minRange = 300;
+							maxRange = 8100;
 						};
 						class GroundTarget {
-							minRange = 7000;
-							maxRange = 7000;
+							minRange = 300;
+							maxRange = 8100;
 						};
 						angleRangeHorizontal = 30;
 						angleRangeVertical = 50;
@@ -322,6 +401,33 @@ class CfgAmmo
 				};
 			};
 		};
+        class ace_missileguidance {
+            enabled = 1;
+
+            minDeflection = 0.0005;      // Minium flap deflection for guidance
+            maxDeflection = 0.01;       // Maximum flap deflection for guidance
+            incDeflection = 0.0005;      // The incrmeent in which deflection adjusts.
+
+            canVanillaLock = 0;          // Can this default vanilla lock? Only applicable to non-cadet mode
+
+            // Guidance type for munitions
+            defaultSeekerType = "SALH";
+            seekerTypes[] = { "SALH", "LIDAR", "SARH", "Optic", "Thermal", "GPS", "SACLOS", "MCLOS" };
+
+            defaultSeekerLockMode = "LOAL";
+            seekerLockModes[] = { "LOAL" };
+
+            seekLastTargetPos = 1;      // seek last target position [if seeker loses LOS of target, continue to last known pos]
+            seekerAngle = 90;           // Angle in front of the missile which can be searched
+            seekerAccuracy = 1;         // seeker accuracy multiplier
+
+            seekerMinRange = 1;
+            seekerMaxRange = 8100;      // Range from the missile which the seeker can visually search
+
+            // Attack profile type selection
+            defaultAttackProfile = "hellfire";
+            attackProfiles[] = {"hellfire", "hellfire_hi", "hellfire_lo"};
+        };
 	};
 	class fza_agm114a : fza_agm114k
 	{		
@@ -340,8 +446,35 @@ class CfgAmmo
 		aiAmmoUsageFlags 			= "128+512";
 		allowAgainstInfantry 		= 0;
 		cost 						= 500;
+        class ace_missileguidance {
+            enabled = 1;
+
+            minDeflection = 0.0005;      // Minium flap deflection for guidance
+            maxDeflection = 0.01;       // Maximum flap deflection for guidance
+            incDeflection = 0.0005;      // The incrmeent in which deflection adjusts.
+
+            canVanillaLock = 0;          // Can this default vanilla lock? Only applicable to non-cadet mode
+
+            // Guidance type for munitions
+            defaultSeekerType = "SALH";
+            seekerTypes[] = { "SALH", "LIDAR", "SARH", "Optic", "Thermal", "GPS", "SACLOS", "MCLOS" };
+
+            defaultSeekerLockMode = "LOAL";
+            seekerLockModes[] = { "LOAL" };
+
+            seekLastTargetPos = 0;      // seek last target position [if seeker loses LOS of target, continue to last known pos]
+            seekerAngle = 90;           // Angle in front of the missile which can be searched
+            seekerAccuracy = 1;         // seeker accuracy multiplier
+
+            seekerMinRange = 1;
+            seekerMaxRange = 7100;      // Range from the missile which the seeker can visually search
+
+            // Attack profile type selection
+            defaultAttackProfile = "hellfire";
+            attackProfiles[] = {"hellfire", "hellfire_hi", "hellfire_lo"};
+        };
 	};
-	class fza_agm114c : fza_agm114k
+	class fza_agm114c : fza_agm114a
 	{
 		fza_salType 				= "sal1";
 		model 						= "\fza_ah64_US\fza_agm114c";
@@ -357,6 +490,33 @@ class CfgAmmo
 		aiAmmoUsageFlags 			= "128+512";
 		allowAgainstInfantry 		= 0;
 		cost 						= 600;
+        class ace_missileguidance {
+            enabled = 1;
+
+            minDeflection = 0.0005;      // Minium flap deflection for guidance
+            maxDeflection = 0.01;       // Maximum flap deflection for guidance
+            incDeflection = 0.0005;      // The incrmeent in which deflection adjusts.
+
+            canVanillaLock = 0;          // Can this default vanilla lock? Only applicable to non-cadet mode
+
+            // Guidance type for munitions
+            defaultSeekerType = "SALH";
+            seekerTypes[] = { "SALH", "LIDAR", "SARH", "Optic", "Thermal", "GPS", "SACLOS", "MCLOS" };
+
+            defaultSeekerLockMode = "LOAL";
+            seekerLockModes[] = { "LOAL" };
+
+            seekLastTargetPos = 1;      // seek last target position [if seeker loses LOS of target, continue to last known pos]
+            seekerAngle = 90;           // Angle in front of the missile which can be searched
+            seekerAccuracy = 1;         // seeker accuracy multiplier
+
+            seekerMinRange = 1;
+            seekerMaxRange = 7100;      // Range from the missile which the seeker can visually search
+
+            // Attack profile type selection
+            defaultAttackProfile = "hellfire";
+            attackProfiles[] = {"hellfire", "hellfire_hi", "hellfire_lo"};
+        };
 	};
 	class fza_agm114m : fza_agm114k
 	{
@@ -375,6 +535,33 @@ class CfgAmmo
 		aiAmmoUsageFlags 			= "64+128+512";
 		allowAgainstInfantry 		= 1;
 		cost 						= 700;
+        class ace_missileguidance {
+            enabled = 1;
+
+            minDeflection = 0.0005;      // Minium flap deflection for guidance
+            maxDeflection = 0.01;       // Maximum flap deflection for guidance
+            incDeflection = 0.0005;      // The incrmeent in which deflection adjusts.
+
+            canVanillaLock = 0;          // Can this default vanilla lock? Only applicable to non-cadet mode
+
+            // Guidance type for munitions
+            defaultSeekerType = "SALH";
+            seekerTypes[] = { "SALH", "LIDAR", "SARH", "Optic", "Thermal", "GPS", "SACLOS", "MCLOS" };
+
+            defaultSeekerLockMode = "LOAL";
+            seekerLockModes[] = { "LOAL" };
+
+            seekLastTargetPos = 1;      // seek last target position [if seeker loses LOS of target, continue to last known pos]
+            seekerAngle = 90;           // Angle in front of the missile which can be searched
+            seekerAccuracy = 1;         // seeker accuracy multiplier
+
+            seekerMinRange = 1;
+            seekerMaxRange = 8100;      // Range from the missile which the seeker can visually search
+
+            // Attack profile type selection
+            defaultAttackProfile = "hellfire";
+            attackProfiles[] = {"hellfire", "hellfire_hi", "hellfire_lo"};
+        };
 	};
 	class fza_agm114n : fza_agm114k
 	{
@@ -391,6 +578,33 @@ class CfgAmmo
 		aiAmmoUsageFlags 			= "64+128+512";
 		allowAgainstInfantry 		= 1;
 		cost 						= 700;
+        class ace_missileguidance {
+            enabled = 1;
+
+            minDeflection = 0.0005;      // Minium flap deflection for guidance
+            maxDeflection = 0.01;       // Maximum flap deflection for guidance
+            incDeflection = 0.0005;      // The incrmeent in which deflection adjusts.
+
+            canVanillaLock = 0;          // Can this default vanilla lock? Only applicable to non-cadet mode
+
+            // Guidance type for munitions
+            defaultSeekerType = "SALH";
+            seekerTypes[] = { "SALH", "LIDAR", "SARH", "Optic", "Thermal", "GPS", "SACLOS", "MCLOS" };
+
+            defaultSeekerLockMode = "LOAL";
+            seekerLockModes[] = { "LOAL" };
+
+            seekLastTargetPos = 1;      // seek last target position [if seeker loses LOS of target, continue to last known pos]
+            seekerAngle = 90;           // Angle in front of the missile which can be searched
+            seekerAccuracy = 1;         // seeker accuracy multiplier
+
+            seekerMinRange = 1;
+            seekerMaxRange = 8100;      // Range from the missile which the seeker can visually search
+
+            // Attack profile type selection
+            defaultAttackProfile = "hellfire";
+            attackProfiles[] = {"hellfire", "hellfire_hi", "hellfire_lo"};
+        };
 	};
 	
 	///////////////////////////////////////////////////////////////////////

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_controls/config/CfgMagazines.hpp
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_controls/config/CfgMagazines.hpp
@@ -102,8 +102,9 @@ class CfgMagazines
 	///////////////////////////////HELLFIRE/////////////////////////////////
 	////////////////////////////////////////////////////////////////////////
 
+	class PylonRack_4Rnd_ACE_Hellfire_AGM114K;
 	#define HELLFIRE_CONFIG(ammoname, disp, descShort) \
-		class ammoname##_ll: 6Rnd_Missile_AGM_02_F { \
+		class ammoname##_ll: PylonRack_4Rnd_ACE_Hellfire_AGM114K { \
 			descriptionShort = descShort;\
 			ammo = ammoname;\
 			model = \fza_ah64_us\weps\pylons\fza_rail_ll.p3d; \

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_controls/config/CfgWeapons.hpp
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_controls/config/CfgWeapons.hpp
@@ -183,7 +183,8 @@ class CfgWeapons
 	//////////////////////////////HELLFIRE/////////////////////////////////
 	///////////////////////////////////////////////////////////////////////
 	
-	class fza_hellfire : MissileLauncher
+	class ace_hellfire_launcher;
+	class fza_hellfire: ace_hellfire_launcher
 	{
 		scope = private;
 		class StandardSound 

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_controls/scripting/functions/mpd/fn_mpdLWPNHandleControl.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_controls/scripting/functions/mpd/fn_mpdLWPNHandleControl.sqf
@@ -32,7 +32,7 @@ if(currentWeapon _heli isKindOf ["fza_hellfire", configFile >> "CfgWeapons"]) th
 		};
 		case "r3": {
 			//Switch missile trajectory of current hellfire
-			[_heli] call fza_fnc_weaponTrajectoryChange;
+			[] call ace_missileguidance_fnc_cycleAttackProfileKeyDown;
 		};
 	};
 };

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_controls/scripting/functions/weapon/fn_weaponMissileSlowDown.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_controls/scripting/functions/weapon/fn_weaponMissileSlowDown.sqf
@@ -11,14 +11,14 @@ if (_projectile isKindOf "fza_agm114l") then {
 		_projectile setMissileTarget _targ;
 	};
 };
-
+/*
 if (_projectile isKindOf "fza_agm114k" || _projectile isKindOf "fza_fim92") then {
     _targ = (_heli getVariable "fza_ah64_currentLase");
 	_distOffAxis = abs ([[_heli, (getposatl _heli select 0), (getposatl _heli select 1), (getposatl _targ select 0), (getposatl _targ select 1)] call fza_fnc_relativeDirection] call CBA_fnc_simplifyAngle180);
 	if (!(isNull _targ) && _distOffAxis < 40) then {
 		_projectile setMissileTarget _targ;
 	};
-};
+};*/
 
 _targ = fza_ah64_mycurrenttarget;
 _heli setVariable ["fza_ah64_shotat_list", (_heli getVariable "fza_ah64_shotat_list")+[_targ], true];

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_controls/scripting/functions/weapon/fn_weaponTrajectoryChange.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_controls/scripting/functions/weapon/fn_weaponTrajectoryChange.sqf
@@ -14,7 +14,7 @@ Examples:
     [_heli] call fza_fnc_weaponTrajectoryChange
 
 Author:
-	Unknown
+	Rosd6(Dryden)
 ---------------------------------------------------------------------------- */
 params ["_heli"];
 

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_controls/scripting/functions/weapon/fn_weaponTrajectoryChange.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_controls/scripting/functions/weapon/fn_weaponTrajectoryChange.sqf
@@ -18,12 +18,18 @@ Author:
 ---------------------------------------------------------------------------- */
 params ["_heli"];
 
-weaponState [_heli, [0]] params ["_weapon", "",  "_fireMode", "_magazine"];
-_nextFireMode = switch (_fireMode) do {
-	case "Cruise": {"TopDown"};
-	case "TopDown": {"LoalDistance"};
-	case "LoalDistance": {"Cruise"};
-	default {["Unknown missile fire mode: %1", _fireMode] call BIS_fnc_error};
+weaponState [_heli, [0]] params ["", "", "", "_magazine"];
+_ammoType = getText (configFile / "CfgMagazines" / _magazine / "ammo");
+if (_ammoType == "fza_agm114l") then {
+	weaponState [_heli, [0]] params ["_weapon", "",  "_fireMode", "_magazine"];
+	_nextFireMode = switch (_fireMode) do {
+		case "Cruise": {"TopDown"};
+		case "TopDown": {"LoalDistance"};
+		case "LoalDistance": {"Cruise"};
+		default {["Unknown missile fire mode: %1", _fireMode] call BIS_fnc_error};
+	};
+	[_heli, [0], _weapon, _nextFireMode, _magazine] call fza_fnc_weaponSelectFireMode;
+	_heli setVariable ["fza_ah64_ltype", _nextFireMode, true];
+} else {
+	[] call ace_missileguidance_fnc_cycleAttackProfileKeyDown;
 };
-[_heli, [0], _weapon, _nextFireMode, _magazine] call fza_fnc_weaponSelectFireMode;
-_heli setVariable ["fza_ah64_ltype", _nextFireMode, true];


### PR DESCRIPTION
The cfg For Ace Laser Hellfire 
keybind to tie in the trajectories with are keybinds
removed vanilla flight profiles for hellfires

THE LIMA Radar hellfire will not use ace hellfire guidance or Flight Profile

# Things that need figuring out 
Retrieve ace hellfire flight mode for hud and mpd
Retrieve and set ace laser code in mpd

```sqf
["ACE3 Equipment", QGVAR(LaserCodeUp), localize LSTRING(laserCodeUp),
{
    [1] call FUNC(keyLaserCodeChange);
},
{false},
[16, [false, true, true]], false, 0] call CBA_fnc_addKeybind; // (ALT+CTRL+Q)

["ACE3 Equipment", QGVAR(LaserCodeDown), localize LSTRING(laserCodeDown),
{

    [-1] call FUNC(keyLaserCodeChange);
},
{false},
[18, [false, true, true]], false, 0] call CBA_fnc_addKeybind; // (ALT+CTRL+E)
```