### PR TITLE
Hide vanilla UI

### DIFF
--- a/@AH-64D Apache Longbow/Addons/fza_ah64_controls/config.cpp
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_controls/config.cpp
@@ -62,3 +62,4 @@ class CfgAddons
 #include "config\CfgDefaultKeysPresets.hpp"
 
 #include "config\CfgVideoOptions.hpp"
+#include "config\CfgUi.hpp"

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_controls/config/CfgUi.hpp
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_controls/config/CfgUi.hpp
@@ -1,0 +1,108 @@
+class RscInGameUI
+{
+    class RscUnitInfoAir;
+    class fza_ah64_rscInfoMinimal: RscUnitInfoAir
+    {
+        onLoad="";
+		controls[] = {
+            "CA_BackgroundVehicle",
+            "CA_BackgroundVehicleTitle",
+            "CA_BackgroundVehicleTitleDark",
+            "CA_BackgroundFuel",
+            "CA_Vehicle",
+            "CA_VehicleRole",
+            "CA_HitZones",
+            "CA_VehicleTogglesBackground",
+            "CA_VehicleToggles",
+            "CA_SpeedBackground",
+            "CA_SpeedUnits",
+            "CA_Speed",
+            "CA_ValueFuel",
+            "CA_AltBackground",
+            "CA_AltUnits",
+            "CA_Alt",
+            "WeaponInfoControlsGroupRight"
+        };
+    };
+    class RscUnitInfoAirRTDBasic;
+    class fza_ah64_rscInfoBasic: RscUnitInfoAirRTDBasic
+    {
+        onLoad="";
+        controls[] = {
+        };
+		controlsx[] = {
+            "WeaponInfoControlsGroupRight",
+            "CA_SpeedBackground",
+            "CA_TextSpeed",
+            "CA_Speed",
+            "CA_AltBackground",
+            "CA_TextAlt",
+            "CA_Alt",
+            "CA_HeadingBackground",
+            "CA_Heading",
+            "CA_ValueColective"
+        };
+    };
+    class RscUnitInfoAirRTDFull;
+    class fza_ah64_rscInfoRTD: RscUnitInfoAirRTDFull
+    {
+        onLoad="";
+        controls[] = {
+            "CA_BackgroundVehicle",
+            "CA_BackgroundVehicleTitle",
+            "CA_BackgroundVehicleTitleDark",
+            "CA_BackgroundFuel",
+            "CA_Vehicle",
+            "CA_VehicleRole",
+            "CA_HitZones",
+            "CA_VehicleTogglesBackground",
+            "CA_VehicleToggles",
+            "CA_SpeedBackground",
+            "CA_SpeedUnits",
+            "CA_Speed",
+            "CA_ValueFuel",
+            "CA_AltBackground",
+            "CA_AltUnits",
+            "CA_Alt",
+            "CA_Horizon_Lite",
+            "CA_Speed_Analogue",
+            "CA_Altitude_Analogue",
+            "CA_Horizon_Analogue",
+            "CA_Stability_Analogue",
+            "CA_Compass_Analogue",
+            "WeaponInfoControlsGroupRight"
+        };
+    };
+};
+
+
+
+
+
+
+    
+/* Original
+    "CA_BackgroundVehicle",
+    "CA_BackgroundVehicleTitle",
+    "CA_BackgroundVehicleTitleDark",
+    "CA_BackgroundFuel",
+    "CA_Vehicle",
+    "CA_VehicleRole",
+    "CA_HitZones",
+    "CA_VehicleTogglesBackground",
+    "CA_VehicleToggles",
+    "CA_SpeedBackground",
+    "CA_SpeedUnits",
+    "CA_Speed",
+    "CA_ValueFuel",
+    "CA_AltBackground",
+    "CA_AltUnits",
+    "CA_Alt",
+    "CA_Horizon_Lite",
+    "CA_Speed_Analogue",
+    "CA_Altitude_Analogue",
+    "CA_Horizon_Analogue",
+    "CA_Stability_Analogue",
+    "CA_Compass_Analogue",
+    "WeaponInfoControlsGroupRight"
+*/

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_controls/config/CfgUi.hpp
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_controls/config/CfgUi.hpp
@@ -5,23 +5,6 @@ class RscInGameUI
     {
         onLoad="";
 		controls[] = {
-            "CA_BackgroundVehicle",
-            "CA_BackgroundVehicleTitle",
-            "CA_BackgroundVehicleTitleDark",
-            "CA_BackgroundFuel",
-            "CA_Vehicle",
-            "CA_VehicleRole",
-            "CA_HitZones",
-            "CA_VehicleTogglesBackground",
-            "CA_VehicleToggles",
-            "CA_SpeedBackground",
-            "CA_SpeedUnits",
-            "CA_Speed",
-            "CA_ValueFuel",
-            "CA_AltBackground",
-            "CA_AltUnits",
-            "CA_Alt",
-            "WeaponInfoControlsGroupRight"
         };
     };
     class RscUnitInfoAirRTDBasic;
@@ -31,16 +14,6 @@ class RscInGameUI
         controls[] = {
         };
 		controlsx[] = {
-            "WeaponInfoControlsGroupRight",
-            "CA_SpeedBackground",
-            "CA_TextSpeed",
-            "CA_Speed",
-            "CA_AltBackground",
-            "CA_TextAlt",
-            "CA_Alt",
-            "CA_HeadingBackground",
-            "CA_Heading",
-            "CA_ValueColective"
         };
     };
     class RscUnitInfoAirRTDFull;
@@ -48,23 +21,6 @@ class RscInGameUI
     {
         onLoad="";
         controls[] = {
-            "CA_BackgroundVehicle",
-            "CA_BackgroundVehicleTitle",
-            "CA_BackgroundVehicleTitleDark",
-            "CA_BackgroundFuel",
-            "CA_Vehicle",
-            "CA_VehicleRole",
-            "CA_HitZones",
-            "CA_VehicleTogglesBackground",
-            "CA_VehicleToggles",
-            "CA_SpeedBackground",
-            "CA_SpeedUnits",
-            "CA_Speed",
-            "CA_ValueFuel",
-            "CA_AltBackground",
-            "CA_AltUnits",
-            "CA_Alt",
-            "CA_Horizon_Lite",
             "CA_Speed_Analogue",
             "CA_Altitude_Analogue",
             "CA_Horizon_Analogue",

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_controls/config/cfgVehicles.hpp
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_controls/config/cfgVehicles.hpp
@@ -103,7 +103,10 @@ class CfgVehicles
 		transportMaxMagazines = 10;
 		transportMaxWeapons = 3;
 		type = VAir;
-		unitinfotype="RscUnitInfoNoHUD";
+		unitinfotype = "fza_ah64_rscInfoMinimal";
+		unitInfoTypeLite = "fza_ah64_rscInfoBasic";
+		unitInfoTypeRTD = "fza_ah64_rscInfoRTD";
+
 		usePreciseGetInAction = 1;
 		emptySound[] = {"", 0, 1};
 		soundGeneralCollision1[] = {"A3\Sounds_F\vehicles\crashes\helis\Heli_coll_default_int_1", 1.000000, 1, 10};


### PR DESCRIPTION
using AFM as a toggle switch system on AFM the analog gauges and weapons menu is visible, otherwise, on SFM everything is hidden 