### PR TITLE
Animation state override

### DIFF
--- a/@AH-64D Apache Longbow/Addons/fza_ah64_AICrew/functions/fn_Enginestart.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_AICrew/functions/fn_Enginestart.sqf
@@ -27,8 +27,8 @@ if ((isplayer driver _heli == false) && _engineState == false && (_heli getVaria
 	_heli setVariable ["fza_ah64_aiESStop", false];
 	//Ai Start up sequence
 	_heli animateSource ["plt_rtrbrake", 0];
-	_heli animate["plt_batt", 1];
-	_heli animate["plt_apu", 1];
+	[_heli, "fza_ah64_battery", true] call fza_fnc_animSetValue;
+	[_heli, "fza_ah64_apu", true] call fza_fnc_animSetValue;
 
 	sleep 1;
 	if (_heli getVariable "fza_ah64_aiESStop") exitwith {[_heli] call fza_aiCrew_fnc_getout};
@@ -59,7 +59,7 @@ if ((isplayer driver _heli == false) && _engineState == false && (_heli getVaria
 	sleep 20;
 	if (_heli getVariable "fza_ah64_aiESStop") exitwith {[_heli] call fza_aiCrew_fnc_getout};
 
-	_heli  animate["plt_apu", 0];
+	[_heli, "fza_ah64_apu", false] call fza_fnc_animSetValue;
 
 	sleep 3;
 	if (_heli getVariable "fza_ah64_aiESStop") exitwith {[_heli] call fza_aiCrew_fnc_getout};

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_AICrew/functions/fn_Enginestart.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_AICrew/functions/fn_Enginestart.sqf
@@ -41,7 +41,7 @@ if ((isplayer driver _heli == false) && _engineState == false && (_heli getVaria
 
 	_heli setVariable ["fza_sfmplus_engPowerLeverState",  	["IDLE", "OFF"]];
 	_heli setVariable ["fza_sfmplus_engState",            	["ON", "OFF"]];
-	_heli animate["plt_eng1_throttle", 0.25, 0.667];
+	[_heli, "fza_ah64_powerLever1", 0.25, 0.667] call fza_fnc_animSetValue;
 
 	sleep 2;
 	if (_heli getVariable "fza_ah64_aiESStop") exitwith {[_heli] call fza_aiCrew_fnc_getout};
@@ -54,7 +54,7 @@ if ((isplayer driver _heli == false) && _engineState == false && (_heli getVaria
 
 	_heli setVariable ["fza_sfmplus_engPowerLeverState",  	["IDLE", "IDLE"]];
 	_heli setVariable ["fza_sfmplus_engState",            	["ON", "ON"]];
-	_heli animate["plt_eng2_throttle", 0.25, 0.667];
+	[_heli, "fza_ah64_powerLever2", 0.25, 0.667] call fza_fnc_animSetValue;
 
 	sleep 20;
 	if (_heli getVariable "fza_ah64_aiESStop") exitwith {[_heli] call fza_aiCrew_fnc_getout};
@@ -65,8 +65,8 @@ if ((isplayer driver _heli == false) && _engineState == false && (_heli getVaria
 	if (_heli getVariable "fza_ah64_aiESStop") exitwith {[_heli] call fza_aiCrew_fnc_getout};
 
 	_heli setVariable ["fza_sfmplus_engPowerLeverState",  	["FLY", "FLY"]];
-	_heli animate["plt_eng1_throttle", 1, 0.063];
-	_heli animate["plt_eng2_throttle", 1, 0.063];
+	[_heli, "fza_ah64_powerLever1", 1, 0.063] call fza_fnc_animSetValue;
+	[_heli, "fza_ah64_powerLever2", 1, 0.063] call fza_fnc_animSetValue;
 
 	_heli setVariable ["fza_ah64_aiESStop", false];
 };

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_AICrew/functions/fn_Enginestart.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_AICrew/functions/fn_Enginestart.sqf
@@ -26,7 +26,7 @@ params ["_heli", "_engineState"];
 if ((isplayer driver _heli == false) && _engineState == false && (_heli getVariable ["fza_ah64_aiESStop", true] == true)) then {
 	_heli setVariable ["fza_ah64_aiESStop", false];
 	//Ai Start up sequence
-	_heli animateSource ["plt_rtrbrake", 0];
+	[_heli, "fza_ah64_rtrbrake", false] call fza_fnc_animSetValue;
 	[_heli, "fza_ah64_battery", true] call fza_fnc_animSetValue;
 	[_heli, "fza_ah64_apu", true] call fza_fnc_animSetValue;
 

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_AICrew/functions/fn_Floodlight.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_AICrew/functions/fn_Floodlight.sqf
@@ -15,7 +15,7 @@ params ["_heli"];
 
 if !fza_ah64_aiFloodlight exitWith {};
 if (isplayer driver _heli && isplayer gunner _heli) exitWith {};
-if (_heli animationphase "plt_batt" < 0.5) exitWith {};
+if !(_heli getVariable "fza_ah64_battery") exitWith {};
 
 private _driver = driver vehicle _heli;
 private _gunner = gunner vehicle _heli;

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_AICrew/functions/fn_getin.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_AICrew/functions/fn_getin.sqf
@@ -27,7 +27,7 @@ if (isplayer _unit) exitWith {};
 if (_unit == driver _heli) then {
     sleep 1.2;
     _heli animateSource ["pdoor", 0];
-	_heli animate["plt_batt", 1];
+    [_heli, "fza_ah64_battery", true] call fza_fnc_animSetValue;
 };
 
 if (_unit == gunner _heli) then {

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_AICrew/functions/fn_getout.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_AICrew/functions/fn_getout.sqf
@@ -32,8 +32,8 @@ if (_unit == driver _heli) then {
 	_heli setVariable ["fza_sfmplus_engStartSwihState", 	["OFF", "OFF"]];
 	_heli setVariable ["fza_sfmplus_engState",            	["OFF", "OFF"]];
 	_heli setVariable ["fza_sfmplus_engPowerLeverState",  	["OFF", "OFF"]];
-	_heli animate["plt_eng1_throttle", 0, 10];
-	_heli animate["plt_eng2_throttle", 0, 10];
+	[_heli, "fza_ah64_powerLever1", 0, 10] call fza_fnc_animSetValue;
+	[_heli, "fza_ah64_powerLever2", 0, 10] call fza_fnc_animSetValue;
 	[_heli, "fza_ah64_apu", false] call fza_fnc_animSetValue;
 	[_heli, "fza_ah64_battery", false] call fza_fnc_animSetValue;
 	[_heli, "fza_ah64_rtrbrake", true] call fza_fnc_animSetValue;

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_AICrew/functions/fn_getout.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_AICrew/functions/fn_getout.sqf
@@ -34,7 +34,7 @@ if (_unit == driver _heli) then {
 	_heli setVariable ["fza_sfmplus_engPowerLeverState",  	["OFF", "OFF"]];
 	_heli animate["plt_eng1_throttle", 0, 10];
 	_heli animate["plt_eng2_throttle", 0, 10];
-	_heli animate["plt_apu", 0];
-	_heli animate["plt_batt", 0];
+	[_heli, "fza_ah64_apu", false] call fza_fnc_animSetValue;
+	[_heli, "fza_ah64_battery", false] call fza_fnc_animSetValue;
 	_heli animateSource ["plt_rtrbrake", 1];
 };

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_AICrew/functions/fn_getout.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_AICrew/functions/fn_getout.sqf
@@ -36,5 +36,5 @@ if (_unit == driver _heli) then {
 	_heli animate["plt_eng2_throttle", 0, 10];
 	[_heli, "fza_ah64_apu", false] call fza_fnc_animSetValue;
 	[_heli, "fza_ah64_battery", false] call fza_fnc_animSetValue;
-	_heli animateSource ["plt_rtrbrake", 1];
+	[_heli, "fza_ah64_rtrbrake", true] call fza_fnc_animSetValue;
 };

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_controls/config/CfgFunctions.hpp
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_controls/config/CfgFunctions.hpp
@@ -9,6 +9,10 @@ class CfgFunctions
 	class fza_ah64_project
 	{
 		tag = "FZA";
+		class anim {
+			file = "\fza_ah64_controls\scripting\functions\avionics";
+			class animSetValue {R;};
+		};
 		class avionics
 		{
 			file = "\fza_ah64_controls\scripting\functions\avionics";

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_controls/config/CfgFunctions.hpp
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_controls/config/CfgFunctions.hpp
@@ -10,8 +10,9 @@ class CfgFunctions
 	{
 		tag = "FZA";
 		class anim {
-			file = "\fza_ah64_controls\scripting\functions\avionics";
+			file = "\fza_ah64_controls\scripting\functions\anim";
 			class animSetValue {R;};
+			class animReset {R;};
 		};
 		class avionics
 		{

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_controls/config/cfgVehicles.hpp
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_controls/config/cfgVehicles.hpp
@@ -1769,12 +1769,14 @@ class CfgVehicles
 				source = "user";
 				animPeriod = 0.001;
 				initPhase=0;
+				onPhaseChanged = "[_heli, ""fza_ah64_rtrbrake"", ""plt_rtrbrake""] call fza_fnc_animReset";
             };
 			class plt_anticollision
             {
 				source = "user";
 				animPeriod = 0.001;
 				initPhase=0;
+				onPhaseChanged = "[_heli, ""fza_ah64_anticollision"", ""plt_anticollision""] call fza_fnc_animReset";
             };
 			class plt_firesw
             {
@@ -1805,12 +1807,14 @@ class CfgVehicles
 				source = "user";
 				animPeriod = 0.001;
 				initPhase=0;
+				onPhaseChanged = "[_heli, ""fza_ah64_battery"", ""plt_batt""] call fza_fnc_animReset";
             };
 			class plt_apu
             {
 				source = "user";
 				animPeriod = 0.001;
 				initPhase=0;
+				onPhaseChanged = "[_heli, ""fza_ah64_apu"", ""plt_apu""] call fza_fnc_animReset";
             };
 			class cpg_ihadss_brt
             {

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_controls/config/cfgVehicles.hpp
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_controls/config/cfgVehicles.hpp
@@ -1499,7 +1499,7 @@ class CfgVehicles
 		{
 			source = "user";
 			animPeriod = 1;
-			initPhase  = 0;
+			initPhase  = 1;
 		};
 		class m230_recoil
 		{
@@ -1780,13 +1780,13 @@ class CfgVehicles
             {
 				source = "user";
 				animPeriod = 0.001;
-				initPhase=0;
+				initPhase=0.5;
             };
 			class cpg_firesw
             {
 				source = "user";
 				animPeriod = 0.001;
-				initPhase=0;
+				initPhase=0.5;
             };
 			class plt_nvsmode
             {

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_controls/config/cfgVehicles.hpp
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_controls/config/cfgVehicles.hpp
@@ -1500,6 +1500,7 @@ class CfgVehicles
 			source = "user";
 			animPeriod = 1;
 			initPhase  = 1;
+			onPhaseChanged = "[_this # 0, ""fza_ah64_tadsStow"", ""tads_stow""] call fza_fnc_animReset";
 		};
 		class m230_recoil
 		{
@@ -1768,15 +1769,15 @@ class CfgVehicles
             {
 				source = "user";
 				animPeriod = 0.001;
-				initPhase=0;
-				onPhaseChanged = "[_heli, ""fza_ah64_rtrbrake"", ""plt_rtrbrake""] call fza_fnc_animReset";
+				initPhase=1;
+				onPhaseChanged = "[_this # 0, ""fza_ah64_rtrbrake"", ""plt_rtrbrake""] call fza_fnc_animReset";
             };
 			class plt_anticollision
             {
 				source = "user";
 				animPeriod = 0.001;
 				initPhase=0;
-				onPhaseChanged = "[_heli, ""fza_ah64_anticollision"", ""plt_anticollision""] call fza_fnc_animReset";
+				onPhaseChanged = "[_this # 0, ""fza_ah64_anticollision"", ""plt_anticollision""] call fza_fnc_animReset";
             };
 			class plt_firesw
             {
@@ -1807,14 +1808,14 @@ class CfgVehicles
 				source = "user";
 				animPeriod = 0.001;
 				initPhase=0;
-				onPhaseChanged = "[_heli, ""fza_ah64_battery"", ""plt_batt""] call fza_fnc_animReset";
+				onPhaseChanged = "[_this # 0, ""fza_ah64_battery"", ""plt_batt""] call fza_fnc_animReset";
             };
 			class plt_apu
             {
 				source = "user";
 				animPeriod = 0.001;
 				initPhase=0;
-				onPhaseChanged = "[_heli, ""fza_ah64_apu"", ""plt_apu""] call fza_fnc_animReset";
+				onPhaseChanged = "[_this # 0, ""fza_ah64_apu"", ""plt_apu""] call fza_fnc_animReset";
             };
 			class cpg_ihadss_brt
             {
@@ -1827,12 +1828,14 @@ class CfgVehicles
 				source = "user";
 				animPeriod = 1;
 				initPhase=0;
+				onPhaseChanged = "[_this # 0, ""fza_ah64_powerLever1"", ""plt_eng1_throttle""] call fza_fnc_animReset";
             };
 			class plt_eng2_throttle
             {
 				source = "user";
 				animPeriod = 1;
 				initPhase=0;
+				onPhaseChanged = "[_this # 0, ""fza_ah64_powerLever2"", ""plt_eng2_throttle""] call fza_fnc_animReset";
             };
 			/*
 			class plt_floodlamps

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_controls/scripting/functions/Sensor/fn_targetingAseUpdate.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_controls/scripting/functions/Sensor/fn_targetingAseUpdate.sqf
@@ -24,7 +24,7 @@ _heli setVariable ["fza_ah64_ASEAudiocounter", (_counter + 1) % 5];
 {
 	_x params ["_ada", "_type", "_sensor"];
 	private _IDfailed = true;
-	if ((vehicle player) animationphase "plt_apu" > 0.5 || (isEngineOn _heli)) then {
+	if (_heli getVariable "fza_ah64_apu" || (isEngineOn _heli)) then {
 		if (!(_type == "missile") && ("radar" in _sensor) && (alive _ADA)) then {
 			//TSD & ASE Draw
 			if !(_ADA in fza_ah64_targetlist) then {

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_controls/scripting/functions/Sensor/fn_targetingSensorUpdate.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_controls/scripting/functions/Sensor/fn_targetingSensorUpdate.sqf
@@ -19,7 +19,7 @@ Author:
 ---------------------------------------------------------------------------- */
 params["_heli"];
 if (!(isNil "fza_ah64_nofcr")) exitwith {};
-if !(_heli animationphase "plt_apu" > 0.5 || (isEngineOn _heli)) exitwith {};
+if !(_heli getVariable "fza_ah64_apu" || (isEngineOn _heli)) exitwith {};
 
 #define AGMODE_GND 0
 #define AGMODE_AIR 1

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_controls/scripting/functions/anim/fn_animReset.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_controls/scripting/functions/anim/fn_animReset.sqf
@@ -1,0 +1,36 @@
+/* ----------------------------------------------------------------------------
+Function: fza_fnc_animReset
+
+Description:
+	Resets an animation to the value on the given variable. Called by
+	onPhaseChanged which is called by bis_fnc_initVehicle.
+
+	It is used to override BIS_fnc_initVehicles overrides of core animations.
+    
+Parameters:
+	_heli - The apache helicopter to check. (Object)
+	_varName - Name of the variable linked to animation. (String)
+	_animName - Animation to be overridden
+
+Returns:
+	Nothing
+
+Examples:
+	--- Code
+    [_heli, "fza_ah64_battery", "plt_batt"] call fza_fnc_animReset
+	---
+
+Author:
+	mattysmith22
+---------------------------------------------------------------------------- */
+params [["_heli", nil, objNull], "_varName", "_animName"];
+
+private _val = _heli getVariable _varName;
+
+if (typeName _val == "BOOL") then {
+	_heli animate [_animName, [0,1] select _val];
+};
+
+if (typeName _val == "SCALAR") then {
+	_heli animate [_animName, _val];
+};

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_controls/scripting/functions/anim/fn_animReset.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_controls/scripting/functions/anim/fn_animReset.sqf
@@ -23,12 +23,12 @@ Examples:
 Author:
 	mattysmith22
 ---------------------------------------------------------------------------- */
-params [["_heli", nil, objNull], "_varName", "_animName"];
+params [["_heli", nil, [objNull]], "_varName", "_animName"];
 
 private _val = _heli getVariable _varName;
 
 if (typeName _val == "BOOL") then {
-	_heli animate [_animName, [0,1] select _val];
+	_heli animate [_animName, parseNumber _val];
 };
 
 if (typeName _val == "SCALAR") then {

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_controls/scripting/functions/anim/fn_animSetValue.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_controls/scripting/functions/anim/fn_animSetValue.sqf
@@ -27,6 +27,7 @@ private _animNames = createHashMapFromArray
 	[["fza_ah64_battery", "plt_batt"]
 	,["fza_ah64_apu", "plt_apu"]
 	,["fza_ah64_rtrbrake", "plt_rtrbrake"]
+	,["fza_ah64_anticollision", "plt_anticollision"]
 	];
 
 private _animName = _animNames get _varName;

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_controls/scripting/functions/anim/fn_animSetValue.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_controls/scripting/functions/anim/fn_animSetValue.sqf
@@ -1,0 +1,44 @@
+/* ----------------------------------------------------------------------------
+Function: fza_fnc_animSetValue
+
+Description:
+	For variables that are linked to an animation, updates the variable value
+	and animates the animation to the value.
+    
+Parameters:
+	_heli - The apache helicopter to check. (Object)
+	_varName - Name of the variable to assign. (String)
+	_value - Value to be assigned to variable (Number or Bool)
+
+Returns:
+	Nothing
+
+Examples:
+	--- Code
+    [_heli, "fza_ah64_battery", true] call fza_fnc_animSetValue
+	---
+
+Author:
+	mattysmith22
+---------------------------------------------------------------------------- */
+params [["_heli", nil, objNull], ["_varName", nil, ""], ["_value", nil, [0,false]]];
+
+private _animNames = createHashMapFromArray
+	[["fza_ah64_battery", "plt_batt"]
+	,["fza_ah64_apu", "plt_apu"]
+	,["fza_ah64_rtrbrake", "plt_rtrbrake"]
+	];
+
+private _animName = _animNames get _varName;
+
+if (isNil "_animName") exitWith {["Variable name not valid: '%1'", _varName] call BIS_fnc_error};
+
+_heli setVariable [_varName, _value, true];
+
+if (typeName _value == "BOOL") then {
+	_heli animate [_animName, parseNumber _value];
+};
+
+if (typeName _value == "SCALAR") then {
+	_heli animate [_animName, value];
+};

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_controls/scripting/functions/anim/fn_animSetValue.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_controls/scripting/functions/anim/fn_animSetValue.sqf
@@ -9,6 +9,7 @@ Parameters:
 	_heli - The apache helicopter to check. (Object)
 	_varName - Name of the variable to assign. (String)
 	_value - Value to be assigned to variable (Number or Bool)
+	_timing - (Optional) timing value to be passed into animate.
 
 Returns:
 	Nothing
@@ -16,30 +17,34 @@ Returns:
 Examples:
 	--- Code
     [_heli, "fza_ah64_battery", true] call fza_fnc_animSetValue
+	[_heli, "fza_ah64_battery", true, 10] call fza_fnc_animSetValue
 	---
 
 Author:
 	mattysmith22
 ---------------------------------------------------------------------------- */
-params [["_heli", nil, objNull], ["_varName", nil, ""], ["_value", nil, [0,false]]];
+params [["_heli", nil, [objNull]], ["_varName", nil, [""]], ["_value", nil, [0,false]], "_timing"];
 
 private _animNames = createHashMapFromArray
 	[["fza_ah64_battery", "plt_batt"]
 	,["fza_ah64_apu", "plt_apu"]
 	,["fza_ah64_rtrbrake", "plt_rtrbrake"]
 	,["fza_ah64_anticollision", "plt_anticollision"]
+	,["fza_ah64_tadsStow", "tads_stow"]
+	,["fza_ah64_powerLever1", "plt_eng1_throttle"]
+	,["fza_ah64_powerLever2", "plt_eng2_throttle"]
 	];
-
+systemChat str _this;
 private _animName = _animNames get _varName;
 
 if (isNil "_animName") exitWith {["Variable name not valid: '%1'", _varName] call BIS_fnc_error};
 
 _heli setVariable [_varName, _value, true];
 
-if (typeName _value == "BOOL") then {
-	_heli animate [_animName, parseNumber _value];
-};
+private _animValue = if (typeName _value != "SCALAR") then {parseNumber _value} else {_value};
 
-if (typeName _value == "SCALAR") then {
-	_heli animate [_animName, value];
+if (isNil "_timing") then {
+	_heli animate [_animName, _animValue];
+} else {
+	_heli animate [_animName, _animValue, _timing];
 };

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_controls/scripting/functions/core/fn_coreGetWCAs.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_controls/scripting/functions/core/fn_coreGetWCAs.sqf
@@ -75,7 +75,7 @@ if (fuel _heli < 0.05) then {
 if (fuel _heli >= 0.05 && fuel _heli < 0.1) then {
 	_wcas pushBack [WCA_CAUTION, "\fza_ah64_us\tex\MPD\AFTFUEL.paa", "\fza_ah64_us\tex\UFD\AFTFUELLO_C_co.paa"];
 };
-if (_heli animationphase "plt_apu" > 0.5 && getpos _heli # 2 >= 3) then {
+if (_heli getVariable "fza_ah64_apu" && getpos _heli # 2 >= 3) then {
 	_wcas pushBack [WCA_CAUTION, "\fza_ah64_us\tex\MPD\APUON.paa", "\fza_ah64_us\tex\UFD\APUON_A_co.paa"]
 };
 if (_heli getHitPointDamage "Hitlfab" >= 0.8) then {
@@ -102,7 +102,7 @@ if (_heli getHit "otocvez" >= 0.8) then {
 if (_heli animationphase "gdoor" > 0 || _heli animationphase "pdoor" > 0) then {
 	_wcas pushBack [WCA_ADVISORY, "\fza_ah64_us\tex\MPD\CANOPY.paa", "\fza_ah64_us\tex\UFD\CANOPYOPEN_A_co.paa"]
 };
-if (_heli animationphase "plt_apu" > 0.5 && getpos _heli # 2 < 3) then {
+if (_heli getVariable "fza_ah64_apu" && getpos _heli # 2 < 3) then {
 	_wcas pushBack [WCA_ADVISORY, "\fza_ah64_us\tex\MPD\APUON.paa", "\fza_ah64_us\tex\UFD\APUON_A_co.paa"]
 };
 if (_heli animationphase "plt_eng1_start" > 0 && _heli animationphase "plt_eng1_throttle" < 0.25) then {

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_controls/scripting/functions/core/fn_coreGetWCAs.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_controls/scripting/functions/core/fn_coreGetWCAs.sqf
@@ -114,7 +114,7 @@ if (_heli animationphase "plt_eng2_start" > 0 && _heli animationphase "plt_eng2_
 if (isAutoHoverOn _heli) then {
 	_wcas pushBack [WCA_ADVISORY, "\fza_ah64_us\tex\MPD\ATTHOLD.paa", "\fza_ah64_us\tex\UFD\ATTHLD_A_co.paa"]
 };
-if (_heli animationphase "plt_rtrbrake" == 1) then {
+if (_heli getVariable "fza_ah64_rtrbrake") then {
 	_wcas pushBack [WCA_ADVISORY, "\fza_ah64_us\tex\MPD\RTRBRKON.paa", "\fza_ah64_us\tex\UFD\RTRBRKON_C_co.paa"]
 };
 

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_controls/scripting/functions/damage/fn_damageEnginefire.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_controls/scripting/functions/damage/fn_damageEnginefire.sqf
@@ -82,7 +82,7 @@ do {
     if (_eng == "apu" && _heli getVariable "fza_ah64_fireapuarm" && ((_firepon && _firepstate) || (_fireron && _firerstate))) exitwith {};
     if (_eng == "left" && (_heli getVariable "fza_sfmplus_engPowerLeverState" select 0 == "off") && _rand > 9.9) exitwith {};
     if (_eng == "right" && (_heli getVariable "fza_sfmplus_engPowerLeverState" select 1 == "off") && _rand > 9.9) exitwith {};
-    if (_eng == "apu" && _heli animationphase "plt_apu" < 0.5 && _rand > 9.9) exitwith {};
+    if (_eng == "apu" && !(_heli getVariable "fza_ah64_apu") && _rand > 9.9) exitwith {};
     _helidamage = _helidamage + 0.0005;
     if (_helidamage > 0.5) then {
         _heli setHit["trans", 1];

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_controls/scripting/functions/engine/fn_engineAPUOn.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_controls/scripting/functions/engine/fn_engineAPUOn.sqf
@@ -20,4 +20,4 @@ Author:
 	mattysmith22
 ---------------------------------------------------------------------------- */
 params ["_heli"];
-_heli animationSourcePhase "plt_apu" > 0.5
+_heli getVariable "fza_ah64_apu"

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_controls/scripting/functions/engine/fn_engineHandleControl.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_controls/scripting/functions/engine/fn_engineHandleControl.sqf
@@ -26,14 +26,14 @@ params ["_heli", "_system", "_control"];
 
 switch(_control) do {
 	case "apu": {
-		if (_heli animationphase "plt_apu" < 1 && _heli animationphase "plt_batt" == 1) then {
-			_heli animateSource["plt_apu", 1];
+		if (!(_heli getVariable "fza_ah64_apu") && _heli getVariable "fza_ah64_battery") then {
+			[_heli, "fza_ah64_apu", true] call fza_fnc_animSetValue;
 			["fza_ah64_apubutton", 0.1, "", 0, "", 0] spawn fza_fnc_playAudio;
 			[_heli] spawn fza_fnc_fxLoops;
 			[_heli, ["fza_ah64_apustart_3D", 200]] remoteExec["say3d"];
 		} else {
-			if (_heli animationphase "plt_apu" == 1) then {
-				_heli animateSource["plt_apu", 0];
+			if (_heli getVariable "fza_ah64_apu") then {
+				[_heli, "fza_ah64_apu", false] call fza_fnc_animSetValue;
 
 				//If either of the apache's engines are in a mode where they are using APU, turn it off.
 				_heliData = _heli getVariable "fza_ah64_engineStates";
@@ -50,12 +50,12 @@ switch(_control) do {
 		};
 	};
 	case "power": {
-	    if (_heli animationphase "plt_batt" < 1) then {
-			_heli animateSource["plt_batt", 1];
+	    if !(_heli getVariable "fza_ah64_battery") then {
+			[_heli, "fza_ah64_battery", true] call fza_fnc_animSetValue;
 			[_heli] spawn fza_fnc_fxLoops;
 			["fza_ah64_battery", 0.1] spawn fza_fnc_playAudio;
 		} else {
-			_heli animateSource["plt_batt", 0];
+			[_heli, "fza_ah64_battery", false] call fza_fnc_animSetValue;
 			_heli animateSource["plt_anticollision", 0];
 			_heli setCollisionLight false;
 			_heli setPilotLight false;

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_controls/scripting/functions/engine/fn_engineHandleControl.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_controls/scripting/functions/engine/fn_engineHandleControl.sqf
@@ -56,7 +56,7 @@ switch(_control) do {
 			["fza_ah64_battery", 0.1] spawn fza_fnc_playAudio;
 		} else {
 			[_heli, "fza_ah64_battery", false] call fza_fnc_animSetValue;
-			_heli animateSource["plt_anticollision", 0];
+			[_heli, "fza_ah64_anticollision", false] call fza_fnc_animSetValue;
 			_heli setCollisionLight false;
 			_heli setPilotLight false;
 			[_heli, ["fza_ah64_fake_3D", 10]] remoteExec["say3d"];
@@ -65,13 +65,8 @@ switch(_control) do {
 	};
 	
 	case "rtrbrake": {
-		if (_heli animationphase "plt_rtrbrake" < 1) then {
-			_heli animateSource["plt_rtrbrake", 1];
-			["fza_ah64_switch_flip2", 0.1] spawn fza_fnc_playAudio;
-		} else {
-			_heli animateSource["plt_rtrbrake", 0];
-			["fza_ah64_switch_flip2", 0.1] spawn fza_fnc_playAudio;
-		};
+		[_heli, "fza_ah64_rtrbrake", !(_heli getVariable "fza_ah64_rtrbrake")] call fza_fnc_animSetValue;
+		["fza_ah64_switch_flip2", 0.1] spawn fza_fnc_playAudio;
 	};
 
 	//--------------------ENGINE 1--------------------//

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_controls/scripting/functions/engine/fn_engineSetPosition.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_controls/scripting/functions/engine/fn_engineSetPosition.sqf
@@ -46,7 +46,7 @@ private _changeMade = false;
 
 switch (_state) do {
     case "OFF":{
-            if (_position == ENGINE_CONTROL_STARTER && !(_otherState in ENGINE_STATE_USING_STARTER) && _heli animationphase "plt_apu" > 0.5) then {
+            if (_position == ENGINE_CONTROL_STARTER && !(_otherState in ENGINE_STATE_USING_STARTER) && _heli getVariable "fza_ah64_apu") then {
                 _state = "OFFSTARTED";
                 _stateParams = time;
                 _changeMade = true;
@@ -72,7 +72,7 @@ switch (_state) do {
 
             _heli animateSource[_engineSwitch, 0];
         };
-        if (_position == ENGINE_CONTROL_THROTTLE_IDLE && _heli animationphase "plt_apu" > 0.5) then {
+        if (_position == ENGINE_CONTROL_THROTTLE_IDLE && _heli getVariable "fza_ah64_apu") then {
             _stateParams = time;
             _state = "STARTEDIDLE";
             _changeMade = true;

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_controls/scripting/functions/engine/fn_engineSetPosition.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_controls/scripting/functions/engine/fn_engineSetPosition.sqf
@@ -24,7 +24,7 @@ Author:
 
 params["_heli", "_engNum", "_position"];
 
-if(_heli animationphase "plt_rtrbrake" != 0) exitWith {};
+if (_heli getVariable "fza_ah64_rtrbrake") exitWith {};
 
 [_heli, 0] call fza_fnc_engineUpdate;
 [_heli, 1] call fza_fnc_engineUpdate;

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_controls/scripting/functions/engine/fn_engineSetPosition.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_controls/scripting/functions/engine/fn_engineSetPosition.sqf
@@ -99,8 +99,8 @@ switch (_state) do {
                         _changeMade = true;
 
                         //0.063 sets the power levers to fly in 16 seconds
-                        _heli animate["plt_eng1_throttle", 1, 0.063];
-                        _heli animate["plt_eng2_throttle", 1, 0.063];
+                        [_heli, "fza_ah64_powerLever1", 1, 0.063] call fza_fnc_animSetValue;
+                        [_heli, "fza_ah64_powerLever2", 1, 0.063] call fza_fnc_animSetValue;
                     }
                 };
             };
@@ -114,8 +114,8 @@ switch (_state) do {
             _changeMade = true;
             
             //0.667 sets the power levers to idle in 1.5 seconds
-            _heli animate["plt_eng1_throttle", 0.25, 0.667];
-            _heli animate["plt_eng2_throttle", 0.25, 0.667];
+            [_heli, "fza_ah64_powerLever1", 0.25, 0.667] call fza_fnc_animSetValue;
+            [_heli, "fza_ah64_powerLever2", 0.25, 0.667] call fza_fnc_animSetValue;
         };
     };
 };

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_controls/scripting/functions/event/fn_eventInit.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_controls/scripting/functions/event/fn_eventInit.sqf
@@ -34,7 +34,9 @@ if (!(_heli getVariable ["fza_ah64_aircraftInitialised", false]) && local _heli)
     _heli setVariable ["fza_ah64_rtrbrake", true, true];
     _heli setVariable ["fza_ah64_battery", false, true];
     _heli setVariable ["fza_ah64_apu", false, true];
-    _heli setVariable ["fza_ah64_tadsStow", true, true]
+    _heli setVariable ["fza_ah64_tadsStow", true, true];
+    _heli setVariable ["fza_ah64_powerLever1", 0, true];
+    _heli setVariable ["fza_ah64_powerLever2", 0, true];
 
     _heli setVariable ["fza_ah64_estarted", false, true];
     _heli setVariable ["fza_ah64_agmode", 0, true];

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_controls/scripting/functions/event/fn_eventInit.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_controls/scripting/functions/event/fn_eventInit.sqf
@@ -34,6 +34,11 @@ if (!(_heli getVariable ["fza_ah64_aircraftInitialised", false]) && local _heli)
     _heli animateSource ["plt_firesw", 0.5];
     _heli animateSource ["cpg_firesw", 0.5];
     _heli animateSource ["tads_stow", 1];
+
+    _heli setVariable ["fza_ah64_rtrbrake", true, true];
+    _heli setVariable ["fza_ah64_battery", false, true];
+    _heli setVariable ["fza_ah64_apu", false, true];
+
     _heli setVariable ["fza_ah64_estarted", false, true];
     _heli setVariable ["fza_ah64_agmode", 0, true];
     _heli setVariable ["fza_ah64_pfzs", [[],[],[],[],[],[],[],[]], true];
@@ -131,7 +136,7 @@ while {
     alive _heli
 }
 do {
-    if ((isLightOn [_heli,[0]]) && _heli animationphase "plt_batt" < 0.5) then {
+    if ((isLightOn [_heli,[0]]) && !(_heli getVariable "fza_ah64_battery")) then {
 
         _heli setobjecttextureGlobal [SEL_IN_BACKLIGHT, ""];
         _heli setobjecttextureGlobal [SEL_IN_BACKLIGHT2, ""];
@@ -141,7 +146,7 @@ do {
     _magsp = _heli magazinesturret[-1];
 
     if (local _heli) then {
-        _tadsShouldBeStowed = _heli animationphase "plt_apu" < 1 && !isEngineOn _heli;
+        _tadsShouldBeStowed = _heli getVariable "fza_ah64_apu" && !isEngineOn _heli;
         
         if (_tadsShouldBeStowed && _heli animationPhase "tads_stow" == 0) then {
             _heli animateSource ["tads_stow", 1];

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_controls/scripting/functions/event/fn_eventInit.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_controls/scripting/functions/event/fn_eventInit.sqf
@@ -30,14 +30,11 @@ _heli addAction ["<t color='#ff0000'>Weapons inhibited</t>", {}, [], -10, false,
 if (!(_heli getVariable ["fza_ah64_aircraftInitialised", false]) && local _heli) then {
     _heli setVariable ["fza_ah64_aircraftInitialised", true, true];
     _heli selectweapon "fza_ma_safe";
-    _heli animateSource ["plt_rtrbrake", 1];
-    _heli animateSource ["plt_firesw", 0.5];
-    _heli animateSource ["cpg_firesw", 0.5];
-    _heli animateSource ["tads_stow", 1];
 
     _heli setVariable ["fza_ah64_rtrbrake", true, true];
     _heli setVariable ["fza_ah64_battery", false, true];
     _heli setVariable ["fza_ah64_apu", false, true];
+    _heli setVariable ["fza_ah64_tadsStow", true, true]
 
     _heli setVariable ["fza_ah64_estarted", false, true];
     _heli setVariable ["fza_ah64_agmode", 0, true];
@@ -148,11 +145,11 @@ do {
     if (local _heli) then {
         _tadsShouldBeStowed = _heli getVariable "fza_ah64_apu" && !isEngineOn _heli;
         
-        if (_tadsShouldBeStowed && _heli animationPhase "tads_stow" == 0) then {
-            _heli animateSource ["tads_stow", 1];
+        if (_tadsShouldBeStowed && !(_heli getVariable "fza_ah64_tadsStow")) then {
+            [_heli, "fza_ah64_tadsStow", true] call fza_fnc_animSetValue;
         };
-        if (!_tadsShouldBeStowed && _heli animationPhase "tads_stow" == 1) then {
-            _heli animateSource ["tads_stow", 0];
+        if (!_tadsShouldBeStowed && _heli getVariable "fza_ah64_tadsStow") then {
+            [_heli, "fza_ah64_tadsStow", false] call fza_fnc_animSetValue;
         };
     };
     sleep 0.03;

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_controls/scripting/functions/fx/fn_fxLoops.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_controls/scripting/functions/fx/fn_fxLoops.sqf
@@ -21,13 +21,13 @@ private _timed_apu = time + 24;
 private _timed_bat = time + 0;
 
 
-if (_heli animationphase "plt_apu" == 1) then {
+if (_heli getVariable "fza_ah64_apu") then {
     private _apu = "Land_ClutterCutter_small_F" createVehicle position _heli;
     _apu attachTo[_heli, [0, 0, 0]];
     hideObjectGlobal _apu;
     
     while {
-        _heli animationphase "plt_apu" == 1
+        _heli getVariable "fza_ah64_apu"
     }
     do {
         if (time > _timed_apu) then {
@@ -39,13 +39,13 @@ if (_heli animationphase "plt_apu" == 1) then {
     deleteVehicle _apu;
 };
 
-if (_heli animationphase "plt_batt" == 1) then {
+if (_heli getVariable "fza_ah64_battery") then {
     private _bat = "Land_ClutterCutter_small_F" createVehicle[0, 0, 0];
     _bat attachTo[_heli, [0, 5, 0]];
     hideObjectGlobal _bat;
 
     while {
-        _heli animationphase "plt_batt" == 1
+        _heli getVariable "fza_ah64_battery"
     }
     do {
         if (time > _timed_bat) then {

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_controls/scripting/functions/ihadss/fn_ihadssDraw.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_controls/scripting/functions/ihadss/fn_ihadssDraw.sqf
@@ -155,7 +155,7 @@ if (cameraView == "GUNNER" && player == gunner _heli && !isEngineOn _heli) then 
 };
 
 //IHADSS INIT
-if (_heli animationphase "plt_apu" > 0.5 && !(_heli getVariable "fza_ah64_monocleinbox") || isEngineOn _heli && !(_heli getVariable "fza_ah64_monocleinbox") || !(_heli getVariable "fza_ah64_monocleinbox")) then {
+if (_heli getVariable "fza_ah64_apu" && !(_heli getVariable "fza_ah64_monocleinbox") || isEngineOn _heli && !(_heli getVariable "fza_ah64_monocleinbox") || !(_heli getVariable "fza_ah64_monocleinbox")) then {
     if (isNil "fza_ah64_ihadssinit") then {
         1 cutrsc["fza_ah64_raddisp", "PLAIN", 0.01, false];
         ((uiNameSpace getVariable "fza_ah64_raddisp") displayCtrl 130) ctrlSetText "\fza_ah64_US\tex\HDU\ihadss.paa";
@@ -185,7 +185,7 @@ if (!(_heli getVariable "fza_ah64_monocleinbox") && cameraView == "INTERNAL") th
 //1ST PERSON VIEW IHADSS BASIC FLIGHT INFO SETUP
 
 if ((gunner _heli == player || driver _heli == player) && !(_heli getVariable "fza_ah64_monocleinbox") && _heli getVariable "fza_ah64_ihadssoff" == 0 && (cameraView == "INTERNAL" || cameraView == "GUNNER")) then {
-    if ((isNull(uiNameSpace getVariable "fza_ah64_raddisp")) && (_heli animationphase "plt_apu" > 0.5 || isEngineOn _heli) && (cameraView == "INTERNAL" || cameraView == "GUNNER")) then {
+    if ((isNull(uiNameSpace getVariable "fza_ah64_raddisp")) && (_heli getVariable "fza_ah64_apu" || isEngineOn _heli) && (cameraView == "INTERNAL" || cameraView == "GUNNER")) then {
         1 cutrsc["fza_ah64_raddisp", "PLAIN", 0.01, false];
 
         ((uiNameSpace getVariable "fza_ah64_raddisp") displayCtrl 121) ctrlSetTextColor[0.1, 1, 0, 1];
@@ -210,13 +210,13 @@ if ((gunner _heli == player || driver _heli == player) && !(_heli getVariable "f
     };
 };
 
-if((vehicle player) animationphase "plt_apu" < 0.5 && !(isEngineOn _heli)) then {
+if(_heli getVariable "fza_ah64_apu" && !(isEngineOn _heli)) then {
     1 cuttext["", "PLAIN"];
     4 cuttext["", "PLAIN"];
 };
 
 //IHADSS FOR GUNNER HEADSDOWN
-if (cameraView == "GUNNER" && player == gunner _heli && (_heli animationphase "plt_apu" > 0.5 || isEngineOn _heli)) then {
+if (cameraView == "GUNNER" && player == gunner _heli && (_heli getVariable "fza_ah64_apu" || isEngineOn _heli)) then {
 
     if !(isNil "_a3ti_vis") then {
         if !(isNil "fza_ah64_bweff") then {

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_controls/scripting/functions/light/fn_lightHandleControl.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_controls/scripting/functions/light/fn_lightHandleControl.sqf
@@ -26,7 +26,7 @@ params ["_heli", "_system", "_control"];
 
 switch (_control) do {
 	case "floodlight": {
-		if (!(isLightOn [_heli,[0]]) && _heli animationphase "plt_batt" > 0.5) then {
+		if (!(isLightOn [_heli,[0]]) && _heli getVariable "fza_ah64_battery") then {
 			_heli setObjectTextureGlobal [SEL_IN_BACKLIGHT, "\fza_ah64_us\tex\in\dlt.paa"];
 			_heli setobjecttextureGlobal [SEL_IN_BACKLIGHT2, "\fza_ah64_us\tex\in\pushbut.paa"];
 
@@ -42,7 +42,7 @@ switch (_control) do {
 		["fza_ah64_button_rotary", 0.1] spawn fza_fnc_playAudio;
 	};
 	case "anticollision": {
-		if (_heli animationphase "plt_anticollision" < 1 && _heli animationphase "plt_batt" > 0.5) then {
+		if (_heli animationphase "plt_anticollision" < 1 && _heli getVariable "fza_ah64_battery") then {
 			_heli animateSource["plt_anticollision", 1];
 			_heli setCollisionLight true;
 		} else {

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_controls/scripting/functions/light/fn_lightHandleControl.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_controls/scripting/functions/light/fn_lightHandleControl.sqf
@@ -42,11 +42,11 @@ switch (_control) do {
 		["fza_ah64_button_rotary", 0.1] spawn fza_fnc_playAudio;
 	};
 	case "anticollision": {
-		if (_heli animationphase "plt_anticollision" < 1 && _heli getVariable "fza_ah64_battery") then {
-			_heli animateSource["plt_anticollision", 1];
+		if (!(_heli getVariable "fza_ah64_anticollision") && _heli getVariable "fza_ah64_battery") then {
+			[_heli, "fza_ah64_anticollision", true] call fza_fnc_animSetValue;
 			_heli setCollisionLight true;
 		} else {
-			_heli animateSource["plt_anticollision", 0];
+			[_heli, "fza_ah64_anticollision", false] call fza_fnc_animSetValue;
 			_heli setCollisionLight false;
 		};
         ["fza_ah64_switch_flip3", 0.1] spawn fza_fnc_playAudio;

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_controls/scripting/functions/mpd/fn_Ufd.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_controls/scripting/functions/mpd/fn_Ufd.sqf
@@ -82,7 +82,7 @@ do {
     _magsg = magazines _heli;
 
     ///end gunner weapon damage//
-    if (_heli animationphase "plt_apu" > 0.5) then {
+    if (_heli getVariable "fza_ah64_apu") then {
         _heli setobjecttexture [SEL_IN_LT_APU, "\fza_ah64_us\tex\in\pushbut.paa"];
     } else {
         _heli setobjecttexture [SEL_IN_LT_APU, ""];
@@ -121,7 +121,7 @@ do {
 
     ///EWCA//
     //pilot
-    if (_heli animationphase "plt_batt" > 0.5) then {
+    if (_heli getVariable "fza_ah64_battery") then {
         _heli setobjecttexture [SEL_UFD_BACK, "\fza_ah64_us\tex\in\ufdon.paa"];
         [_heli, fuel _heli * 2538, "\fza_ah64_us\tex\CHAR\G", SEL_DIGITS_G_UFD_FL] call fza_fnc_drawNumberSelections;
         [_heli, fuel _heli * 2538, "\fza_ah64_us\tex\CHAR\G", SEL_DIGITS_P_UFD_FL] call fza_fnc_drawNumberSelections;

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_controls/scripting/functions/mpd/fn_mpdUpdateDisplays.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_controls/scripting/functions/mpd/fn_mpdUpdateDisplays.sqf
@@ -23,11 +23,11 @@ params ["_heli"];
 (_heli getVariable "fza_ah64_mpdPage") params ["_lmpdNext", "_rmpdNext"];
 (_heli getVariable "fza_ah64_mpdCurrPage") params ["_lmpdCurr", "_rmpdCurr"];
 
-if (_heli animationphase "plt_batt" < 0.5 && (_lmpdCurr != "OFF" || _rmpdCurr != "OFF")) then {
+if (!(_heli getVariable "fza_ah64_battery") && (_lmpdCurr != "OFF" || _rmpdCurr != "OFF")) then {
 	[_heli, 1, "off"] call fza_fnc_mpdSetDisplay;
 	[_heli, 0, "off"] call fza_fnc_mpdSetDisplay;
 };
-if ((_heli animationphase "plt_batt" > 0.5) && (_lmpdCurr == "OFF" || _rmpdCurr == "OFF")) then {
+if (_heli getVariable "fza_ah64_battery" && (_lmpdCurr == "OFF" || _rmpdCurr == "OFF")) then {
 	[_heli, 0, "fuel"] call fza_fnc_mpdSetDisplay;
 	[_heli, 1, "eng"] call fza_fnc_mpdSetDisplay;
 };

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_controls/scripting/functions/targeting/fn_targetingPNVSControl.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_controls/scripting/functions/targeting/fn_targetingPNVSControl.sqf
@@ -20,7 +20,7 @@ Author:
 ---------------------------------------------------------------------------- */
 params["_heli"];
 if (player == driver _heli && (vehicle player) isKindOf "fza_ah64base") then {
-    if (player == driver _heli && (_heli animationphase "plt_apu" > 0.5 || isengineon _heli)) then {
+    if (player == driver _heli && (_heli getVariable "fza_ah64_apu" || isengineon _heli)) then {
         if (isNil "fza_ah64_pnvsgreff") then {
             fza_ah64_pnvsgreff = ppEffectCreate ["colorCorrections",4000];
         };
@@ -67,7 +67,7 @@ if (player == driver _heli && (vehicle player) isKindOf "fza_ah64base") then {
     };
 	
 	// BACKUP TURRET OPTIC PNVS WITH BOTH LOGICS
-	if(player == driver _heli && (_heli animationphase "plt_apu" > 0.5 || isengineon _heli)) then
+	if(player == driver _heli && (_heli getVariable "fza_ah64_apu" || isengineon _heli)) then
 	{
         if (isNil "fza_ah64_pnvsgreff") then {
             fza_ah64_pnvsgreff = ppEffectCreate ["colorCorrections",4000];

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_sfmplus/functions/core/fn_coreUpdate.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_sfmplus/functions/core/fn_coreUpdate.sqf
@@ -43,7 +43,7 @@ private _eng1FF = _heli getVariable "fza_sfmplus_engFF" select 0;
 private _eng2FF = _heli getVariable "fza_sfmplus_engFF" select 1;
 private _curFuelFlow = 0;
 
-if (_heli animationphase "plt_apu" > 0.5) then {
+if (_heli getVariable "fza_ah64_apu") then {
 	_apuFF = 0.0220;	//175pph
 };
 _curFuelFlow    = (_apuFF + _eng1FF + _eng2FF) * _deltaTime;

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_sfmplus/functions/interact/fn_interactPowerLever.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_sfmplus/functions/interact/fn_interactPowerLever.sqf
@@ -21,7 +21,7 @@ Author:
 ---------------------------------------------------------------------------- */
 params ["_heli", "_engNum", "_state"];
 
-if(_heli animationphase "plt_rtrbrake" != 0) exitWith {};
+if (_heli getVariable "fza_ah64_rtrbrake") exitWith {};
 
 private _engState = _heli getVariable "fza_sfmplus_engState" select _engNum;
 private _engPwrLeverAnimName = format["plt_eng%1_throttle", _engNum + 1]; 

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_sfmplus/functions/interact/fn_interactPowerLever.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_sfmplus/functions/interact/fn_interactPowerLever.sqf
@@ -24,10 +24,10 @@ params ["_heli", "_engNum", "_state"];
 if (_heli getVariable "fza_ah64_rtrbrake") exitWith {};
 
 private _engState = _heli getVariable "fza_sfmplus_engState" select _engNum;
-private _engPwrLeverAnimName = format["plt_eng%1_throttle", _engNum + 1]; 
+private _engPwrLeverAnimName = format["fza_ah64_powerLever%1", _engNum + 1]; 
 
 if (_state == "OFF") then {
-	_heli animateSource[_engPwrLeverAnimName, 0];
+	[_heli, _engPwrLeverAnimName, 0] call fza_fnc_animSetValue;
 	[_heli, "fza_sfmplus_engPowerLeverState", _engNum, _state, true] call fza_sfmplus_fnc_setArrayVariable;
 
 	if (_engState == "ON") then {
@@ -39,7 +39,7 @@ if (_state == "OFF") then {
 };
 
 if (_state == "IDLE") then {
-	_heli animateSource[_engPwrLeverAnimName, 0.25];
+	[_heli, _engPwrLeverAnimName, 0.25] call fza_fnc_animSetValue;
 	[_heli, "fza_sfmplus_engPowerLeverState", _engNum, _state, true] call fza_sfmplus_fnc_setArrayVariable;
 
 	//HeliSim
@@ -48,7 +48,7 @@ if (_state == "IDLE") then {
 
 if (_state == "FLY") then {
 	//0.063 sets the power levers to fly in 16 seconds
-	_heli animateSource[_engPwrLeverAnimName, 1, 0.25];
+	[_heli, _engPwrLeverAnimName, 1, 0.25] call fza_fnc_animSetValue;
 	[_heli, "fza_sfmplus_engPowerLeverState", _engNum, _state, true] call fza_sfmplus_fnc_setArrayVariable;
 
 	//HeliSim

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_sfmplus/functions/interact/fn_interactStartSwitch.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_sfmplus/functions/interact/fn_interactStartSwitch.sqf
@@ -19,7 +19,7 @@ Author:
 ---------------------------------------------------------------------------- */
 params ["_heli", "_engNum"];
 
-if(_heli animationphase "plt_rtrbrake" != 0) exitWith {};
+if (_heli getVariable "fza_ah64_rtrbrake") exitWith {};
 
 private _engState    = _heli getVariable "fza_sfmplus_engState" select _engNum;
 


### PR DESCRIPTION
Fixes #77 by moving all (important) state onto variables rather than animations, and using that instead. A separate script is used to override anything done by `BIS_fnc_initVehicle` (garage system) and re-apply the value from the variable onto the animation.