### PR TITLE
Service Ceiling	adjustment from default

### DIFF
--- a/@AH-64D Apache Longbow/Addons/fza_ah64_controls/config/cfgVehicles.hpp
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_controls/config/cfgVehicles.hpp
@@ -57,8 +57,8 @@ class CfgVehicles
 	    fuelCapacity           = 1423;
 		fuelconsumptionrate    = 0.0;
 		maxSpeed               = 298;
-		altFullForce 		   = 5000;
-		altNoForce 			   = 6800;
+		altFullForce 		   = 1615;
+		altNoForce 			   = 9000;
 		//SFM Variables-------------/
 
 		side=1;

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_controls/config/cfgVehicles.hpp
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_controls/config/cfgVehicles.hpp
@@ -57,6 +57,8 @@ class CfgVehicles
 	    fuelCapacity           = 1423;
 		fuelconsumptionrate    = 0.0;
 		maxSpeed               = 298;
+		altFullForce 		   = 5000;
+		altNoForce 			   = 6800;
 		//SFM Variables-------------/
 
 		side=1;


### PR DESCRIPTION
by default, the apache could only reach 14,599 feet asl
now it can hit at maximum of 19,960 feet ASL