### PR TITLE
Incoming missile warning fix

### DIFF
--- a/@AH-64D Apache Longbow/Addons/fza_ah64_controls/scripting/XEH_preInit.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_controls/scripting/XEH_preInit.sqf
@@ -128,6 +128,7 @@ fza_ah64_tsdmap = 0;
 fza_ah64_Cscopelist = [];
 fza_ah64_hducolor = [0.1, 1, 0, 1];
 fza_ah64_introShownThisScenario = false;
+fza_ah64_incomingmissiles = [];
 
 //Scheduler arrays
 fza_ah64_draw3Darray     = [fza_fnc_weaponTurretAim, fza_fnc_targetingPNVSControl, fza_fnc_targetingSched, fza_fnc_avionicsSlipIndicator, fza_fnc_navigationWaypointEta, fza_fnc_ihadssDraw, fza_fnc_mpdUpdateDisplays];

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_controls/scripting/functions/event/fn_eventIncomingMissile.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_controls/scripting/functions/event/fn_eventIncomingMissile.sqf
@@ -66,7 +66,4 @@ _this spawn fza_fnc_aseBetty;
     
     fza_ah64_threatfiring = fza_ah64_threatfiring - [_hostile];
 };
-
-//empty array to keep it small for less performance impact over time
-sleep 60;
-fza_ah64_incomingmissiles deleteAt 0;
+fza_ah64_incomingmissiles = fza_ah64_incomingmissiles - [objNull];

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_controls/scripting/functions/event/fn_eventIncomingMissile.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_controls/scripting/functions/event/fn_eventIncomingMissile.sqf
@@ -69,4 +69,4 @@ _this spawn fza_fnc_aseBetty;
 
 //empty array to keep it small for less performance impact over time
 sleep 60;
-fza_ah64_incomingmissiles = fza_ah64_incomingmissiles - _missile;
+fza_ah64_incomingmissiles deleteAt 0;

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_controls/scripting/functions/event/fn_eventIncomingMissile.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_controls/scripting/functions/event/fn_eventIncomingMissile.sqf
@@ -66,3 +66,7 @@ _this spawn fza_fnc_aseBetty;
     
     fza_ah64_threatfiring = fza_ah64_threatfiring - [_hostile];
 };
+
+//empty array to keep it small for less performance impact over time
+sleep 60;
+fza_ah64_incomingmissiles = fza_ah64_incomingmissiles - _missile;

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_controls/scripting/functions/event/fn_eventIncomingMissile.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_controls/scripting/functions/event/fn_eventIncomingMissile.sqf
@@ -22,16 +22,12 @@ Author:
 params ["_heli","_munition","_hostile", "_instigator"];
 
 if (!local _heli) exitWith {}; //Should've also have been run on the local machine
-
-private _counter = _hostile getVariable ["fza_ah64_shotCounter", 0];
-_hostile setVariable ["fza_ah64_shotCounter", (_counter + 1) % 2];
-if (_counter % 2 == 1) exitWith {};
-
 if(!(_munition isKindOf "missileBase") || !(isengineon _heli || (alive _heli))) exitwith {};
-
 private _missile = nearestobject [_hostile,_munition];
-
 if !(missileTarget _missile == _heli) exitwith {}; // Would this ever be true?
+
+if (_missile in fza_ah64_incomingmissiles) exitwith {};
+fza_ah64_incomingmissiles pushback _missile;
 
 //Add target info to databases
 fza_ah64_threatfiring pushBackUnique vehicle _instigator;


### PR DESCRIPTION
Grabbing the missile itself as an object & sticking it in an array which I then check in other instances.
#169 