### PR TITLE
SFM Plus Anti-Lift Update

### DIFF
--- a/@AH-64D Apache Longbow/Addons/fza_ah64_controls/config/cfgVehicles/sfmplus.hpp
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_controls/config/cfgVehicles/sfmplus.hpp
@@ -2,15 +2,17 @@ class Fza_SfmPlus {
     emptyMassFCR    = 6609; //kg
     emptyMassNonFCR = 6314; //kg
 
-    stabPos[]  = {0.0, -7.207, -0.50};
-    stabWidth  = 3.22;  //m
-    stabLength = 1.07; //m
+    stabPos[]  = {0.0, -7.207, -0.50};  //m
+    stabWidth  = 3.22;                  //m
+    stabLength = 1.07;                  //m
+
+    forcePos[] = {0.0, 2.08, 0.83};     //m
 
     initFuelFracRobbie   = 0.39;
     initFuelFracNoRobbie = 0.22;
-    maxFwdFuelMass = 473;   //1043lbs in kg
-    maxCtrFuelMass = 301;   //663lbs in kg, net yet implemented, center robbie
-    maxAftFuelMass = 669;   //1474lbs in kg
+    maxFwdFuelMass       = 473;   //1043lbs in kg
+    maxCtrFuelMass       = 301;   //663lbs in kg, net yet implemented, center robbie
+    maxAftFuelMass       = 669;   //1474lbs in kg
     //maxExtFuelMass = 690; //1541lbs in kg, not yet implemented, 230gal external tank
 
     //Engine Data

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_sfmplus/cfgFunctions.hpp
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_sfmplus/cfgFunctions.hpp
@@ -29,6 +29,10 @@ class CfgFunctions
             class engineReset {R;};
 			class engineVariables {R;};
 		};
+		class forceGenerators {
+			file = "\fza_ah64_sfmplus\functions\forceGenerators";
+			class antiLift {R;};
+		};
 		class fuel {
 			file = "\fza_ah64_sfmplus\functions\fuel";
 			class fuelSet {R;};

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_sfmplus/functions/core/fn_coreConfig.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_sfmplus/functions/core/fn_coreConfig.sqf
@@ -20,12 +20,14 @@ params ["_heli"];
 
 private _config = configFile >> "CfgVehicles" >> typeof _heli >> "Fza_SfmPlus";
 
-_heli setVariable ["fza_sfmplus_emptyMassFCR",    	getNumber (_config >> "emptyMassFCR")]; //kg
-_heli setVariable ["fza_sfmplus_emptyMassNonFCR", 	getNumber (_config >> "emptyMassNonFCR")]; //kg
+_heli setVariable ["fza_sfmplus_emptyMassFCR",    	getNumber (_config >> "emptyMassFCR")]; 	//kg
+_heli setVariable ["fza_sfmplus_emptyMassNonFCR", 	getNumber (_config >> "emptyMassNonFCR")]; 	//kg
 
 _heli setVariable ["fza_sfmplus_stabPos", 			getArray  (_config >> "stabPos")];
-_heli setVariable ["fza_sfmplus_stabWidth", 		getNumber (_config >> "stabWidth")];  //m
-_heli setVariable ["fza_sfmplus_stabLength", 		getNumber (_config >> "stabLength")]; //m
+_heli setVariable ["fza_sfmplus_stabWidth", 		getNumber (_config >> "stabWidth")];  	//m
+_heli setVariable ["fza_sfmplus_stabLength", 		getNumber (_config >> "stabLength")]; 	//m
+
+_heli setVariable ["fza_sfmplus_forcePos",			getArray (_config >> "forcePos")];		//m
 
 _heli setVariable ["fza_sfmplus_maxFwdFuelMass", 	getNumber (_config >> "maxFwdFuelMass")];	//1043lbs in kg
 _heli setVariable ["fza_sfmplus_maxCtrFuelMass",    getNumber (_config >> "maxCtrFuelMass")];	//663lbs in kg, net yet implemented, center robbie

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_sfmplus/functions/core/fn_coreUpdate.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_sfmplus/functions/core/fn_coreUpdate.sqf
@@ -83,6 +83,9 @@ if(fza_ah64_sfmPlusStabilatorEnabled == STABILTOR_MODE_ALWAYSENABLED
 //Perormance
 [_heli] call fza_sfmplus_fnc_perfData;
 
+//Apply a negative force to prevent the helicopter from taking off until the power levers are at fly
+[_heli, _deltaTime] call fza_sfmplus_fnc_antiLift;
+
 #ifdef __A3_DEBUG_
 /*
 hintsilent format ["v0.11

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_sfmplus/functions/damage/fn_damageApply.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_sfmplus/functions/damage/fn_damageApply.sqf
@@ -42,7 +42,7 @@ if (isEngineOn _heli) then {
         _applyDamage = true;
     };
 
-    if (_pctNR <= 0.9 && (_eng1PctTQ >= 0.7 || getpos _heli select 2 > 1)) then {
+    if (_pctNR <= 0.9 && _eng1PctTQ >= 0.7) then {
         _applyDamage = true;
     };
     //With the power levers at fly

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_sfmplus/functions/engine/fn_engine.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_sfmplus/functions/engine/fn_engine.sqf
@@ -69,7 +69,7 @@ if (_engPowerLeverState != "OFF") then {
 //Ng
 _engBaseNG = _engIdleNG + (_engFlyNG - _engIdleNG) * _engThrottle;
 //Np
-_engBaseNP = _engIdleNP + (_engFlyNP - _engIdleNP) * _engThrottle; 
+_engBaseNP = _engIdleNP + (_engFlyNP - _engIdleNP) * _engThrottle;
 
 switch (_engState) do {
 	case "OFF": {

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_sfmplus/functions/engine/fn_engineController.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_sfmplus/functions/engine/fn_engineController.sqf
@@ -23,15 +23,16 @@ private _engState  = _heli getVariable "fza_sfmplus_engState";
 private _eng1State = _engState select 0;
 private _eng2State = _engState select 1;
 
-if ((_eng1State == "STARTING" || _eng2State == "STARTING") && local _heli) then {
+private _engPwrLvrState  = _heli getVariable "fza_sfmplus_engPowerLeverState";
+private _eng1PwrLvrState = _engPwrLvrState select 0;
+private _eng2PwrLvrState = _engPwrLvrState select 1;
+
+if (((_eng1State == "STARTING" && _eng1PwrLvrState == "IDLE") || (_eng2State == "STARTING" && _eng2PwrLvrState == "IDLE")) && local _heli) then {
 	_heli setVariable ["fza_ah64_estarted", true, true];
 	_heli engineOn true;
 };
 
 private _isSingleEng     = _heli getVariable "fza_sfmplus_isSingleEng";
-private _engPwrLvrState  = _heli getVariable "fza_sfmplus_engPowerLeverState";
-private _eng1PwrLvrState = _engPwrLvrState select 0;
-private _eng2PwrLvrState = _engPwrLvrState select 1;
 
 if ((_eng1PwrLvrState isEqualTo _eng2PwrLvrState) && (_eng1State == "ON" && _eng2State == "ON")) then {
 	_isSingleEng = false;

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_sfmplus/functions/fn_getInput.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_sfmplus/functions/fn_getInput.sqf
@@ -22,6 +22,7 @@ private _collectiveVal = _heli animationSourcePhase "collective";
 
 private _collectiveOut = 0.0;
 if (fza_ah64_sfmPlusKeyboardOnly) then {
+	_collectiveVal = [_collectiveVal, 0.5, 1.0] call BIS_fnc_clamp;
 	_collectiveOut = linearConversion[ 0.5, 1.0, _collectiveVal, 0.0, 2.0];
 
 	private _V_mps            = abs vectorMagnitude [velocity _heli select 0, velocity _heli select 1];

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_sfmplus/functions/forceGenerators/fn_antiLift.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_sfmplus/functions/forceGenerators/fn_antiLift.sqf
@@ -1,0 +1,54 @@
+/* ----------------------------------------------------------------------------
+Function: fza_sfmplus_fnc_antiLift
+
+Description:
+	Applies a negative lift force if the player attempts to takeoff with the
+    engines at idle.
+
+Parameters:
+	_heli - The helicopter to get information from [Unit].
+
+Returns:
+	...
+
+Examples:
+	...
+
+Author:
+	BradMick
+---------------------------------------------------------------------------- */
+params ["_heli", "_deltaTime"];
+
+private _colorRed = [1,0,0,1]; private _colorGreen = [0,1,0,1]; private _colorBlue = [0,0,1,1]; private _colorWhite = [1,1,1,1];
+
+DRAW_LINE = {
+	params ["_heli", "_p1", "_p2", "_col"];
+	drawLine3D [_heli modelToWorldVisual _p1, _heli modelToWorldVisual _p2, _col];
+};
+
+if (isEngineOn _heli) then {
+    private _objCtr        = _heli selectionPosition ["modelCenter", "Memory"];
+    private _forcePos      = _heli getVariable "fza_sfmplus_forcePos";
+    private _forceVec      = [0.0, 0.0, 1.0];   //X, Z, Y
+    private _forceVec_norm = vectorNormalized(_forcePos vectorAdd _forceVec);
+
+    private _eng1Np        = _heli getVariable "fza_sfmplus_engPctNP" select 0;
+    private _eng2Np        = _heli getVariable "fza_sfmplus_engPctNP" select 1;
+    private _rtrRPM        = _eng1Np max _eng2Np;
+    private _forceVal      = 0.15;
+    private _forceMult     = linearConversion[0.0, 0.98, _rtrRPM, _forceVal, 0.0];
+    _forceMult = [_forceMult, 0.0, _forceVal] call BIS_fnc_clamp;
+
+    private _curMass       = getMass _heli;
+    private _negLiftForce  = ((_curMass * -9.806) * _forceMult) * fza_sfmplus_collectiveOutput;
+    _negLiftForce          = [_negLiftForce, 0.0, (1.0 / 15.0) * _deltaTime] call BIS_fnc_lerp;
+    private _negLift       = _forceVec vectorMultiply _negLiftForce;
+
+    _heli addForce[_heli vectorModelToWorld _negLift, _forcePos];
+
+    #ifdef __A3_DEBUG__
+    //Draw the force vector
+    [_heli, _forcePos, _forcePos vectorAdd _forceVec, _colorGreen] call DRAW_LINE;
+
+    #endif
+};


### PR DESCRIPTION
-Removed damage incurred from flying around with the power levers at idle.
-Implemented a negative lift force to prevent the player from taking off (leaving the throttle maxed for appx 3 seconds will cause a 'spring board' effect and cause the aircraft to crash)
-Added forcePos to enable antiLift function
-AntiLift also prevents the player from bringing the power levers to idle in flight to circumvent torque limits.