### PR TITLE
Forced manual fire mode on before changing magazines

### DIFF
--- a/@AH-64D Apache Longbow/Addons/fza_ah64_controls/scripting/functions/weapon/fn_weaponUpdateSelected.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_controls/scripting/functions/weapon/fn_weaponUpdateSelected.sqf
@@ -19,6 +19,10 @@ Author:
 params["_heli"];
 if !(_heli turretLocal [0]) exitWith {};
 
+if (player == driver _heli && !isPlayer gunner _heli && !isManualFire _heli) then {
+	player action ["ManualFire", vehicle player];
+};
+
 switch (_heli getVariable "fza_ah64_was") do {
 	case WAS_WEAPON_NONE: {
 		_heli selectWeaponTurret ["fza_ma_safe",[0]];


### PR DESCRIPTION
Context: When you select a weapon using 1234, there is nothing we can do to stop the weapon from switching AFAIK. I've tried all but one idea for it. So instead we wait a single frame, and then override the value

If you are in the pilot's seat, have manual fire enabled, the swap is instantaneous. However, if you aren't when you press down a key, the switch doesn't happen in the same frame, but a half second or so after, so our code overrides the magazine too early and then gets overridden itself 