### PR TITLE
Simple Rotor Magic Number Fix

### DIFF
--- a/@AH-64D Apache Longbow/Addons/fza_ah64_sfmplus/headers/core.hpp
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_sfmplus/headers/core.hpp
@@ -22,3 +22,8 @@
 #define DEG_C_TO_KELVIN         273.15
 #define SEA_LEVEL_PRESSURE      29.92
 #define STANDARD_TEMP           15
+
+#define VEL_ETL                 12.35
+#define VEL_BEST_ENDURANCE      36.0111 //70 kts
+#define VEL_VRS                 24.384
+#define ISA_STD_DAY_AIR_DENSITY 1.225


### PR DESCRIPTION
Moved magic numbers for simple rotor to core.hpp, replaced existing magic number calls in simple rotor with new config entries, replaced magic number in _airspeedVelocityScalar with _rtrAirspeedVelocityMod