### PR TITLE
Fixed HeliSim Collective position not synchronising between joystick and keyboard and mouse

### DIFF
--- a/@AH-64D Apache Longbow/Addons/fza_ah64_sfmplus/functions/engine/fn_engineVariables.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_sfmplus/functions/engine/fn_engineVariables.sqf
@@ -20,7 +20,6 @@ params ["_heli"];
 
 _heli setVariable ["fza_sfmplus_engPowerLeverState",  	["OFF", "OFF"]]; //OFF, IDLE, FLY
 _heli setVariable ["fza_sfmplus_engState",            	["OFF", "OFF"]]; //OFF, STARTING, ON
-_heli setVariable ["fza_sfmplus_collectiveVal",			0.0];
 
 if(isMultiplayer) then {
 	_heli setVariable ["fza_sfmplus_lastTimePropagated", 0];


### PR DESCRIPTION
Specifically, if you had for example a collective value of 60% with joystick and tapped the increase or decrease collective keys, it would snap to whatever the value for the keyboard/mouse was, say 20%.

This was caused by two separate variables for the collective, which we have merged into a single variable.