### PR TITLE
Fix fire test interaction

### DIFF
--- a/@AH-64D Apache Longbow/Addons/fza_ah64_controls/headers/controls.h
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_controls/headers/controls.h
@@ -64,7 +64,7 @@ COCKPIT_CONTROL("ctrlref_p_fapu", "ctrlref_g_fapu",fire, "Fire Panel",fapu, 0.04
 COCKPIT_CONTROL("ctrlref_p_fe2", "ctrlref_g_fe2",fire, "Fire Panel",fe2, 0.04, "Fire Engine 2") COCKPIT_CONTROL_SEP
 COCKPIT_CONTROL("ctrlref_p_fbp", "ctrlref_g_fbp",fire, "Fire Panel",fbp, 0.04, "Fire Bottle Primary") COCKPIT_CONTROL_SEP
 COCKPIT_CONTROL("ctrlref_p_fbr", "ctrlref_g_fbr",fire, "Fire Panel",fbr, 0.04, "Fire Bottle Reserve") COCKPIT_CONTROL_SEP
-COCKPIT_CONTROL("ctrlref_p_swfiretst", "ctrlref_g_swfiretst",fire, "Fire Panel",test, 0.4, "Fire Test") COCKPIT_CONTROL_SEP
+COCKPIT_CONTROL("ctrlref_p_swfiretst", "ctrlref_g_swfiretst",fire, "Fire Panel",test, 0.04, "Fire Test") COCKPIT_CONTROL_SEP
 
 COCKPIT_CONTROL("ctrlref_p_doorhandle", "ctrlref_g_doorhandle",door, "Door",handle, 0.09, "Pilot Door Handle") COCKPIT_CONTROL_SEP
 


### PR DESCRIPTION
Missing 0 caused interaction point to be to large