### PR TITLE
Eden Dms Auto Cycle

### DIFF
--- a/@AH-64D Apache Longbow/Addons/fza_ah64_dms/CfgFunctions.hpp
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_dms/CfgFunctions.hpp
@@ -19,6 +19,8 @@ class CfgFunctions
         class eden {
             file = "\fza_ah64_dms\functions\eden";
             class edenPointModify{R;};
+            class edenPointNext{R;};
+            class edenPointDeleted{R;};
         };
         class point {
             file = "\fza_ah64_dms\functions\point";

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_dms/CfgVehicles.hpp
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_dms/CfgVehicles.hpp
@@ -7,6 +7,8 @@ class CfgVehicles {
         class EventHandlers: EventHandlers {
             class fza_dms {
                 init = "[_this # 0] call fza_dms_fnc_init"; //<-- C51 always is the user positio
+                CuratorObjectDeleted = "_this call fza_dms_fnc_edenPointDeleted";
+                Deleted = "_this call fza_dms_fnc_edenPointDeleted";
             };
         };
     };
@@ -57,6 +59,12 @@ class CfgVehicles {
                 condition = "1";
             };
         };
+        class EventHandlers: EventHandlers {
+            class fza_dms {
+                CuratorObjectDeleted = "_this call fza_dms_fnc_edenPointDeleted";
+                Deleted = "_this call fza_dms_fnc_edenPointDeleted";
+            };
+        };
     };
 
     class fza_dms_point_wp_hz : fza_dms_point_base {
@@ -66,7 +74,7 @@ class CfgVehicles {
         class Attributes : Attributes {
             class fza_dms_point_index : fza_dms_point_index {
                 tooltip = "Waypoint/Hazards are allowed to range from 1-50";
-                defaultValue = "1";
+                defaultValue = "([""waypointsHazards""] call fza_dms_fnc_edenPointNext)+1;";
             };
             class fza_dms_point_ident : fza_dms_point_ident {
                 defaultValue = "'WP'";
@@ -83,7 +91,7 @@ class CfgVehicles {
         class Attributes : Attributes {
             class fza_dms_point_index : fza_dms_point_index {
                 tooltip = "Control Measures are allowed to range from 51-99."; //Beware that Present Positions (PPOS) will overwrite CM 93 thru 99.
-                defaultValue = "51";
+                defaultValue = "([""controlMeasures""] call fza_dms_fnc_edenPointNext)+51;";
             };
             class fza_dms_point_ident : fza_dms_point_ident {
                 defaultValue = "'CP'";
@@ -100,7 +108,7 @@ class CfgVehicles {
         class Attributes : Attributes {
             class fza_dms_point_index : fza_dms_point_index {
                 tooltip = "Target/Threats are allowed to range from 1-50";
-                defaultValue = "1";
+                defaultValue = "([""targetsThreats""] call fza_dms_fnc_edenPointNext)+1;";
             };
             class fza_dms_point_ident : fza_dms_point_ident {
                 defaultValue = "'TG'";

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_dms/functions/eden/fn_edenPointDeleted.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_dms/functions/eden/fn_edenPointDeleted.sqf
@@ -1,0 +1,2 @@
+copyToClipboard str _this;
+systemchat str _this;

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_dms/functions/eden/fn_edenPointNext.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_dms/functions/eden/fn_edenPointNext.sqf
@@ -1,0 +1,22 @@
+
+params ["_type"];
+
+private _return = 50;
+private _index  = -1;
+switch (_type) do {
+    case "waypointsHazards": {
+        _waypointsHazards = missionnamespace getVariable "fza_dms_waypointsHazards";
+        _index = _waypointsHazards findIf {_x isequalto -1};
+    };
+    case "controlMeasures": {
+        _controlMeasures = missionnamespace getVariable "fza_dms_controlMeasures";
+        _index = _controlMeasures findIf {_x isequalto -1};
+    };
+    case "targetsThreats": {
+        _targets = missionnamespace getVariable "fza_dms_targetsThreats";
+        _index = _targets findIf {_x isequalto -1};
+    };
+};
+
+if (_index isNotEqualTo -1) then {_return = _index;};
+_return;


### PR DESCRIPTION
Cycles the entry in the Eden DMS logic points to the next available index.
Pre-existing issue means points that have been deleted have not been removed from missionnamespace,  blocking the cycler's access to it