### PR TITLE
Add empty MFD pylonicon entries to prevent RPT spam caused by missing entries

### DIFF
--- a/@AH-64D Apache Longbow/Addons/fza_ah64_mpd/pylons/hellfire_rf.hpp
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_mpd/pylons/hellfire_rf.hpp
@@ -237,3 +237,11 @@ class fza_ah64_M299_inverse {
         };
     };
 };
+
+//Empty pylon icon definitions to supress RPT warnings that they are missing
+//even though these are for a different type of weapon
+class fza_ah64_rocket {
+    class Bones{};
+    class Draw{};
+};
+class fza_ah64_rocket_inverse: fza_ah64_rocket {};

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_mpd/pylons/hellfire_sal1.hpp
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_mpd/pylons/hellfire_sal1.hpp
@@ -235,3 +235,11 @@ class fza_ah64_M299_inverse {
         };
     };
 };
+
+//Empty pylon icon definitions to supress RPT warnings that they are missing
+//even though these are for a different type of weapon
+class fza_ah64_rocket {
+    class Bones{};
+    class Draw{};
+};
+class fza_ah64_rocket_inverse: fza_ah64_rocket {};

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_mpd/pylons/hellfire_sal2.hpp
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_mpd/pylons/hellfire_sal2.hpp
@@ -242,3 +242,11 @@ class fza_ah64_M299_inverse {
         };
     };
 };
+
+//Empty pylon icon definitions to supress RPT warnings that they are missing
+//even though these are for a different type of weapon
+class fza_ah64_rocket {
+    class Bones{};
+    class Draw{};
+};
+class fza_ah64_rocket_inverse: fza_ah64_rocket {};

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_mpd/pylons/rocket.hpp
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_mpd/pylons/rocket.hpp
@@ -96,3 +96,14 @@ class fza_ah64_rocket_inverse {
             };
         };
     };
+
+//Empty pylon icon definitions to supress RPT warnings that they are missing
+//even though these are for a different type of weapon
+class fza_ah64_M299 {
+    class Bones{};
+    class Draw{};
+};
+class fza_ah64_M299_inverse: fza_ah64_M299 {};
+class fza_ah64_hellfire: fza_ah64_M299 {};
+class fza_ah64_hellfire_inverse: fza_ah64_M299 {};
+class fza_ah64_hellfire_selected: fza_ah64_M299 {};


### PR DESCRIPTION
Fixes #449 