### PR TITLE
BUGFIX FCR Config Enabled Sync

### DIFF
--- a/@AH-64D Apache Longbow/Addons/fza_ah64_controls/config/cfgVehicles/animationSources.hpp
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_controls/config/cfgVehicles/animationSources.hpp
@@ -5,7 +5,6 @@ class AnimationSources
     {
         displayName = "Mount FCR (Fire Control Radar)";
         author = "AH-64D Development Team";
-        onPhaseChanged = "_this # 0 enableVehicleSensor [""ActiveRadarSensorComponent"",_this # 1 == 1];";
         source = "user";
         initPhase = 0;
         animPeriod = 0.001;

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_customise/functions/fn_add.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_customise/functions/fn_add.sqf
@@ -28,7 +28,6 @@ if (_targetComp == "FCR") exitwith {
             private _nearestObject = nearestObject [_player, "fza_ah64_FireControlRadar"];
             deleteVehicle _nearestObject;
             _target animateSource ["fcr_enable",1];
-            _target enableVehicleSensor ["ActiveRadarSensorComponent", true];
         },
         {},
         localize "STR_A3_MP_GroundSupport_ProgressBar_LoadingGroup",

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_customise/functions/fn_remove.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_customise/functions/fn_remove.sqf
@@ -27,7 +27,6 @@ if (_targetComp == "FCR") exitwith {
             params ["_args"];
             _args params ["_target", "_player"];
             _target animateSource ["fcr_enable", 0];
-            _target enableVehicleSensor ["ActiveRadarSensorComponent", false];
             private _object = "fza_ah64_FireControlRadar" createVehicle [0,0,0];
             [_player, _object] call ace_dragging_fnc_carryObject;
         },

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_fcr/functions/fn_controller.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_fcr/functions/fn_controller.sqf
@@ -19,6 +19,13 @@ Author:
 params ["_heli"];
 
 if ((player != driver _heli) && (isplayer driver _heli)) exitwith {};
+
+if (_heli animationPhase "fcr_enable" == 0) then {
+    _heli enableVehicleSensor ["ActiveRadarSensorComponent", false];
+} else {
+    _heli enableVehicleSensor ["ActiveRadarSensorComponent", true];
+};
+
 if (_heli animationPhase "fcr_enable" != 1) exitwith {};
 
 [_heli] call fza_fcr_fnc_stateControl;

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_fcr/functions/fn_init.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_fcr/functions/fn_init.sqf
@@ -31,5 +31,3 @@ if (!(_heli getVariable ["fza_ah64_fcrInitialised", false]) && local _heli) then
     _heli setVariable ["fza_ah64_fcrMode", 1, true];
     _heli setVariable ["fza_ah64_fcrcscope", false, true];
 };
-
-_heli enableVehicleSensor ["ActiveRadarSensorComponent", _heli animationPhase "fcr_enable" == 1];


### PR DESCRIPTION
OnPhaseChange - does not reliably change the config sensor active state, and even when it does, it can still have a desync between the radars availability between crew seats