### PR TITLE
Fix ARH Seeker Lag from Redundant Target Search

### DIFF
--- a/@AH-64D Apache Longbow/Addons/fza_ah64_hellfire/functions/fn_arhSeeker.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_hellfire/functions/fn_arhSeeker.sqf
@@ -25,11 +25,12 @@ Author:
 params ["", "_args", "_seekerStateParams", "", "_timestep"];
 _args params ["_firedEH", "_launchParams", "", "_seekerParams", "_stateParams", "_targetData", "_navigationStateParams"];
 _firedEH params ["_shooter","","","","","","_projectile"];
-_launchParams params ["_target","","","",""];
+_launchParams params ["_lastTarget","","","",""];
 _seekerParams params ["_seekerAngle", "", "_seekerMaxRange"];
 _seekerStateParams params ["_isActive", "_timeWhenActive", "_expectedTargetPos", "_calulatedSearchPos", "_lastTargetPollTime", "_lastKnownVelocity", "_lastTimeSeen", "_doesntHaveTarget", "_targetType"];
 
 #define ACTIVE_RADAR_MINIMUM_SCAN_AREA 50
+private _target = objNull;
 
 if (!_isActive && { CBA_missionTime  <= _timeWhenActive }) exitwith {
     _expectedTargetPos
@@ -39,54 +40,56 @@ if !_isActive then {
     _seekerStateParams set [0, true];
 };
 
-if ((_lastTargetPollTime + (1 / 7)) - CBA_missionTime < 0) then {
-    _seekerStateParams set [4, CBA_missionTime];
-    private _searchPos = _calulatedSearchPos;
-    if (_searchPos isEqualTo [0, 0, 0]) exitwith {};
-    _target = objNull;
-    private _distanceToExpectedTarget = FCR_LIMIT_FORCE_LOBL_RANGE min ((getPosASL _projectile) vectorDistance _searchPos);
+if (([_projectile, [getpos _lastTarget, speed _lastTarget, _lastTarget], true] call fza_hellfire_fnc_limaLoblCheck)#1) then {
+    _target = _lastTarget;
+} else {
+    if ((_lastTargetPollTime + (1 / 7)) - CBA_missionTime < 0) then {
+        _seekerStateParams set [4, CBA_missionTime];
+        private _searchPos = _calulatedSearchPos;
+        if (_searchPos isEqualTo [0, 0, 0]) exitwith {};
+        private _distanceToExpectedTarget = FCR_LIMIT_FORCE_LOBL_RANGE min ((getPosASL _projectile) vectorDistance _searchPos);
 
-    // Simulate how much the seeker can see at the ground
-    private _projDir = vectorDir _projectile;
-    private _projYaw = getDir _projectile;
-    private _rotatedYaw = (+(_projDir select 0) * sin _projYaw) + (+(_projDir select 1) * cos _projYaw);
-    if (_rotatedYaw isEqualTo 0) then { _rotatedYaw = 0.001 };
-    private _projPitch = atan ((_projDir select 2) / _rotatedYaw);
-    private _a1 = abs _projPitch;
-    private _a2 = 180 - ((_seekerAngle / 3) + _a1);
-    private _seekerBaseRadiusAtGround = ACTIVE_RADAR_MINIMUM_SCAN_AREA max (_distanceToExpectedTarget / sin(_a2) * sin(_seekerAngle / 2));
-    private _seekerBaseRadiusAdjusted = linearConversion [0, _seekerBaseRadiusAtGround, (CBA_missionTime - _lastTimeSeen) * vectorMagnitude _lastKnownVelocity, ACTIVE_RADAR_MINIMUM_SCAN_AREA, _seekerBaseRadiusAtGround, false];
-    if (_doesntHaveTarget) then {
-        _seekerBaseRadiusAdjusted = _seekerBaseRadiusAtGround;
-    };
-    // Look in front of seeker for any targets
-    private _nearestObjects = nearestObjects [ASLtoAGL _searchPos, ["all"], _seekerBaseRadiusAdjusted, false];
-    _nearestObjects = _nearestObjects select {([_projectile, [getpos _x, speed _x, _x], true] call fza_hellfire_fnc_limaLoblCheck)#1};
-    // Select closest object to the expected position to be the current radar target
-    if (_nearestObjects isEqualTo []) exitWith {
-        _projectile setMissileTarget objNull;
-        _expectedTargetPos
-    };
+        // Simulate how much the seeker can see at the ground
+        private _projDir = vectorDir _projectile;
+        private _projYaw = getDir _projectile;
+        private _rotatedYaw = (+(_projDir select 0) * sin _projYaw) + (+(_projDir select 1) * cos _projYaw);
+        if (_rotatedYaw isEqualTo 0) then { _rotatedYaw = 0.001 };
+        private _projPitch = atan ((_projDir select 2) / _rotatedYaw);
+        private _a1 = abs _projPitch;
+        private _a2 = 180 - ((_seekerAngle / 3) + _a1);
+        private _seekerBaseRadiusAtGround = ACTIVE_RADAR_MINIMUM_SCAN_AREA max (_distanceToExpectedTarget / sin(_a2) * sin(_seekerAngle / 2));
+        private _seekerBaseRadiusAdjusted = linearConversion [0, _seekerBaseRadiusAtGround, (CBA_missionTime - _lastTimeSeen) * vectorMagnitude _lastKnownVelocity, ACTIVE_RADAR_MINIMUM_SCAN_AREA, _seekerBaseRadiusAtGround, false];
+        if (_doesntHaveTarget) then {
+            _seekerBaseRadiusAdjusted = _seekerBaseRadiusAtGround;
+        };
+        // Look in front of seeker for any targets
+        private _nearestObjects = nearestObjects [ASLtoAGL _searchPos, ["all"], _seekerBaseRadiusAdjusted, false];
+        _nearestObjects = _nearestObjects select {([_projectile, [getpos _x, speed _x, _x], true] call fza_hellfire_fnc_limaLoblCheck)#1};
+        // Select closest object to the expected position to be the current radar target
+        if (_nearestObjects isEqualTo []) exitWith {
+            _projectile setMissileTarget objNull;
+            _expectedTargetPos
+        };
 
-    private _primaryTargets = _nearestObjects select {
-        _targTypeCompare = (_x call BIS_fnc_objectType)#1;
-        (_targetType isEqualTo _targTypeCompare)
-    };
-    private _secondaryTargets = _nearestObjects - _primaryTargets;
-    _primaryTargets = [_primaryTargets, [], {_x distance _searchPos}, "ASCEND"] call BIS_fnc_sortBy;
-    _secondaryTargets = [_secondaryTargets, [], {_x distance _searchPos}, "ASCEND"] call BIS_fnc_sortBy;
+        private _primaryTargets = _nearestObjects select {
+            _targTypeCompare = (_x call BIS_fnc_objectType)#1;
+            (_targetType isEqualTo _targTypeCompare)
+        };
+        private _secondaryTargets = _nearestObjects - _primaryTargets;
+        _primaryTargets = [_primaryTargets, [], {_x distance _searchPos}, "ASCEND"] call BIS_fnc_sortBy;
+        _secondaryTargets = [_secondaryTargets, [], {_x distance _searchPos}, "ASCEND"] call BIS_fnc_sortBy;
 
-    if (_primaryTargets isNotEqualTo []) then {
-        _target = _primaryTargets#0
-    } else {
-        if (_secondaryTargets isNotEqualTo []) then {
-            _target = _secondaryTargets#0
-            //_seekerStateParams set [8, (_target call BIS_fnc_objectType)#1]; // Might cause unexpected behaviour in terminal, uncomment in future if needed
+        if (_primaryTargets isNotEqualTo []) then {
+            _target = _primaryTargets#0
+        } else {
+            if (_secondaryTargets isNotEqualTo []) then {
+                _target = _secondaryTargets#0
+                //_seekerStateParams set [8, (_target call BIS_fnc_objectType)#1]; // Might cause unexpected behaviour in terminal, uncomment in future if needed
+            };
         };
     };
 };
 
-_projectile setMissileTarget _target;
 
 if !(isNull _target) then {
     private _centerOfObject = getCenterOfMass _target;
@@ -100,6 +103,8 @@ if !(isNull _target) then {
 
     _targetData set [2, _projectile distance _target];
     _targetData set [3, velocity _target];
+    
+    _launchParams set [0, _target];
 
     if (_timestep != 0) then {
         private _acceleration = ((velocity _target) vectorDiff _lastKnownVelocity) vectorMultiply (1 / _timestep);

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_light/functions/fn_controller.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_light/functions/fn_controller.sqf
@@ -70,9 +70,6 @@ if !_powerOnState then {
     if (!_anticollval && _anticollanim) then {
         _heli setCollisionLight true;
     };
-    if (_anticollval && !_anticollanim) then {
-        _heli setCollisionLight false;
-    };
 };
 
 private _turret = _heli call fza_fnc_currentTurret;

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_light/functions/fn_controller.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_light/functions/fn_controller.sqf
@@ -70,6 +70,9 @@ if !_powerOnState then {
     if (!_anticollval && _anticollanim) then {
         _heli setCollisionLight true;
     };
+    if (_anticollval && !_anticollanim) then {
+        _heli setCollisionLight false;
+    };
 };
 
 private _turret = _heli call fza_fnc_currentTurret;


### PR DESCRIPTION
Just added a LOS check on the last target before searching again