### PR TITLE
HeliSim M&K Fix

### DIFF
--- a/@AH-64D Apache Longbow/Addons/fza_ah64_controls/XEH_preInit.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_controls/XEH_preInit.sqf
@@ -59,6 +59,15 @@ private _projName = "AH-64D Official Project";
 ] call CBA_fnc_addSetting;
 
 [
+    "fza_ah64_sfmplusEnableKbPitchTrim",
+    "CHECKBOX",
+    ["[EXPERIMENTAL] Enable KB Pitch Trim", "When enabled, retains the position of the cyclic."],
+    [_projName, "Flight model"],
+    [false],
+    0
+] call CBA_fnc_addSetting;
+
+[
     "fza_ah64_sfmPlusMouseSense",
     "SLIDER",
     ["Mouse Sensitivity", "Controls the sensitivity of the Mouse when used as a Joystick."],

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_sfmplus/functions/aero/fn_aeroStabilator.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_sfmplus/functions/aero/fn_aeroStabilator.sqf
@@ -162,12 +162,12 @@ for "_j" from 0 to (_numElements - 1) do {
 
     private _relativeWind = (_heli getVariable "fza_sfmplus_velModelSpace") vectorMultiply -1.0;
 
-    //private _fromAeroCenterToCOM = _e vectorDiff _heliCOM;
-    //private _angularVel   = (_heli getVariable "fza_sfmplus_angVelModelSpace");
+    private _fromAeroCenterToCOM = _e vectorDiff _heliCOM;
+    private _angularVel   = (_heli getVariable "fza_sfmplus_angVelModelSpace");
 
-    //private _localRelWind = (vectorNormalized _angularVel) vectorCrossProduct (vectorNormalized _fromAeroCenterToCOM);
-    //_localRelWind         = _localRelWind vectorMultiply -((vectorMagnitude _angularVel) * (vectorMagnitude _fromAeroCenterToCOM));
-    //_relativeWind         = _relativeWind vectorAdd _localRelWind;
+    private _localRelWind = (vectorNormalized _angularVel) vectorCrossProduct (vectorNormalized _fromAeroCenterToCOM);
+    _localRelWind         = _localRelWind vectorMultiply -((vectorMagnitude _angularVel) * (vectorMagnitude _fromAeroCenterToCOM));
+    _relativeWind         = _relativeWind vectorAdd _localRelWind;
 
     #ifdef __A3_DEBUG__
     [_heli, _e vectorDiff (vectorNormalized _relativeWind), _e, "red"] call fza_fnc_debugDrawLine;

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_sfmplus/functions/aero/fn_aeroStabilator.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_sfmplus/functions/aero/fn_aeroStabilator.sqf
@@ -80,13 +80,25 @@ _stabOutputTable = [
                    ,[84.88, _intStabTable select 13]  //165kts
                    ,[92.60, _intStabTable select 14]  //180kts
                    ];
+/*
+_stabOutputTable = [
+                    [15.43, -25.0]   //30kts
+                   ,[20.58,   0.0]   //40kts
+                   ,[36.01,  -2.5]   //70kts
+                   ,[46.30,  -5.0]   //90kts
+                   ,[61.73,  -7.8]   //120kts
+                   ,[66.88, -10.0]  //130kts
+                   ];
+*/
                    
 if (_stabDamage < SYS_STAB_DMG_THRESH || _dcBusOn) then {
     _desiredTheta = [_stabOutputTable, (_heli getVariable "fza_sfmplus_vel2D") * KNOTS_TO_MPS] call fza_fnc_linearInterp select 1;
-    _theta = [_theta, _desiredTheta, (1.0 / 1.5) * _deltaTime] call BIS_fnc_lerp;
+    _theta        = [_theta, _desiredTheta, (1.0 / 1.5) * _deltaTime] call BIS_fnc_lerp;
     _heli setVariable ["fza_ah64_stabilatorPosition", _theta];
 };
 
+//_theta = THETA;
+//systemChat format ["_theta = %1 -- _collectiveOutput = %2", _theta, (_heli getVariable "fza_sfmplus_collectiveOutput")];
 //Animate the Horizontal stabilizer
 _heli animate ["Hstab", _theta];
 
@@ -107,6 +119,7 @@ private _B_wingTipLeadingEdge   = _stabPos vectorAdd  (_vectorRight vectorMultip
 private _C_wingTipTrailingEdge  = _B_wingTipLeadingEdge  vectorDiff (_vectorForward vectorMultiply _chord);
 private _D_wingRootTrailingEdge = _A_wingRootLeadingEdge vectorDiff (_vectorForward vectorMultiply _chord);
 
+//_theta                  = THETA;
 _theta                  = _theta * -1.0;
 
 private _stabRoot       = _A_wingRootLeadingEdge vectorDiff _D_wingRootTrailingEdge;
@@ -141,7 +154,7 @@ for "_j" from 0 to (_numElements - 1) do {
 
     private _chordLine   = (_a vectorAdd ((_b vectorDiff _a) vectorMultiply 0.5)) vectorDiff (_d vectorAdd ((_c vectorDiff _d) vectorMultiply 0.5));
     private _chordLength = vectorMagnitude _chordLine;
-    _chordLine = vectorNormalized _chordLine;
+    _chordLine           = vectorNormalized _chordLine;
 
     #ifdef __A3_DEBUG__
     [_heli, _e, _e vectorAdd _chordLine, "blue"] call fza_fnc_debugDrawLine;
@@ -149,12 +162,12 @@ for "_j" from 0 to (_numElements - 1) do {
 
     private _relativeWind = (_heli getVariable "fza_sfmplus_velModelSpace") vectorMultiply -1.0;
 
-    private _fromAeroCenterToCOM = _e vectorDiff _heliCOM;
-    private _angularVel = (_heli getVariable "fza_sfmplus_angVelWorldSpace");
+    //private _fromAeroCenterToCOM = _e vectorDiff _heliCOM;
+    //private _angularVel   = (_heli getVariable "fza_sfmplus_angVelModelSpace");
 
-    private _localRelWind = (vectorNormalized _angularVel) vectorCrossProduct (vectorNormalized _fromAeroCenterToCOM);
-    _localRelWind         = _localRelWind vectorMultiply -((vectorMagnitude _angularVel) * (vectorMagnitude _fromAeroCenterToCOM));
-    _relativeWind         = _relativeWind vectorAdd _localRelWind;
+    //private _localRelWind = (vectorNormalized _angularVel) vectorCrossProduct (vectorNormalized _fromAeroCenterToCOM);
+    //_localRelWind         = _localRelWind vectorMultiply -((vectorMagnitude _angularVel) * (vectorMagnitude _fromAeroCenterToCOM));
+    //_relativeWind         = _relativeWind vectorAdd _localRelWind;
 
     #ifdef __A3_DEBUG__
     [_heli, _e vectorDiff (vectorNormalized _relativeWind), _e, "red"] call fza_fnc_debugDrawLine;
@@ -170,7 +183,7 @@ for "_j" from 0 to (_numElements - 1) do {
     #endif
 
     private _relativeWindNormalized = vectorNormalized _relativeWind;
-    private _aoa = _chordLine vectorDotProduct (_relativeWindNormalized vectorMultiply -1.0);
+    private _aoa                    = _chordLine vectorDotProduct (_relativeWindNormalized vectorMultiply -1.0);
     _aoa = [_aoa, -1.0, 1.0] call BIS_fnc_clamp;
     _aoa = acos _aoa;
 
@@ -190,7 +203,6 @@ for "_j" from 0 to (_numElements - 1) do {
     private _CL          = [_airfoilTable, _aoa] call fza_fnc_linearInterp select 1;
     private _v           = vectorMagnitude _relativeWind;
     private _lift        = _CL * 0.5 * _rho * _area * (_v * _v);
-
     //Drag coefficient
     private _CD          = [_airfoilTable, _aoa] call fza_fnc_linearInterp select 2;
     private _drag        = _CD * 0.5 * _rho * _area * (_v * _v);

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_sfmplus/functions/aero/fn_aeroStabilator.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_sfmplus/functions/aero/fn_aeroStabilator.sqf
@@ -162,12 +162,12 @@ for "_j" from 0 to (_numElements - 1) do {
 
     private _relativeWind = (_heli getVariable "fza_sfmplus_velModelSpace") vectorMultiply -1.0;
 
-    private _fromAeroCenterToCOM = _e vectorDiff _heliCOM;
-    private _angularVel   = (_heli getVariable "fza_sfmplus_angVelModelSpace");
+    //private _fromAeroCenterToCOM = _e vectorDiff _heliCOM;
+    //private _angularVel   = (_heli getVariable "fza_sfmplus_angVelModelSpace");
 
-    private _localRelWind = (vectorNormalized _angularVel) vectorCrossProduct (vectorNormalized _fromAeroCenterToCOM);
-    _localRelWind         = _localRelWind vectorMultiply -((vectorMagnitude _angularVel) * (vectorMagnitude _fromAeroCenterToCOM));
-    _relativeWind         = _relativeWind vectorAdd _localRelWind;
+    //private _localRelWind = (vectorNormalized _angularVel) vectorCrossProduct (vectorNormalized _fromAeroCenterToCOM);
+    //_localRelWind         = _localRelWind vectorMultiply -((vectorMagnitude _angularVel) * (vectorMagnitude _fromAeroCenterToCOM));
+    //_relativeWind         = _relativeWind vectorAdd _localRelWind;
 
     #ifdef __A3_DEBUG__
     [_heli, _e vectorDiff (vectorNormalized _relativeWind), _e, "red"] call fza_fnc_debugDrawLine;

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_sfmplus/functions/aero/fn_aeroWing.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_sfmplus/functions/aero/fn_aeroWing.sqf
@@ -74,7 +74,7 @@ for "_j" from 0 to (_numElements - 1) do {
 
     private _chordLine   = (_a vectorAdd ((_b vectorDiff _a) vectorMultiply 0.5)) vectorDiff (_d vectorAdd ((_c vectorDiff _d) vectorMultiply 0.5));
     private _chordLength = vectorMagnitude _chordLine;
-    _chordLine = vectorNormalized _chordLine;
+    _chordLine           = vectorNormalized _chordLine;
 
     #ifdef __A3_DEBUG__
     [_heli, _e, _e vectorAdd _chordLine, "blue"] call fza_fnc_debugDrawLine;
@@ -82,12 +82,12 @@ for "_j" from 0 to (_numElements - 1) do {
 
     private _relativeWind = (_heli getVariable "fza_sfmplus_velModelSpace") vectorMultiply -1.0;
 
-    private _fromAeroCenterToCOM = _e vectorDiff _heliCOM;
-    private _angularVel = (_heli getVariable "fza_sfmplus_angVelWorldSpace");
+    //private _fromAeroCenterToCOM = _e vectorDiff _heliCOM;
+    //private _angularVel          = (_heli getVariable "fza_sfmplus_angVelModelSpace");
 
-    private _localRelWind = (vectorNormalized _angularVel) vectorCrossProduct (vectorNormalized _fromAeroCenterToCOM);
-    _localRelWind         = _localRelWind vectorMultiply -((vectorMagnitude _angularVel) * (vectorMagnitude _fromAeroCenterToCOM));
-    _relativeWind         = _relativeWind vectorAdd _localRelWind;
+    //private _localRelWind = (vectorNormalized _angularVel) vectorCrossProduct (vectorNormalized _fromAeroCenterToCOM);
+    //_localRelWind         = _localRelWind vectorMultiply -((vectorMagnitude _angularVel) * (vectorMagnitude _fromAeroCenterToCOM));
+    //_relativeWind         = _relativeWind vectorAdd _localRelWind;
 
     #ifdef __A3_DEBUG__
     [_heli, _e vectorDiff (vectorNormalized _relativeWind), _e, "red"] call fza_fnc_debugDrawLine;
@@ -103,7 +103,7 @@ for "_j" from 0 to (_numElements - 1) do {
     #endif
 
     private _relativeWindNormalized = vectorNormalized _relativeWind;
-    private _AoA = _chordLine vectorDotProduct (_relativeWindNormalized vectorMultiply -1.0);
+    private _AoA                    = _chordLine vectorDotProduct (_relativeWindNormalized vectorMultiply -1.0);
     _AoA = [_AoA, -1.0, 1.0] call BIS_fnc_clamp;
     _AoA = acos _AoA;
 

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_sfmplus/functions/aero/fn_aeroWing.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_sfmplus/functions/aero/fn_aeroWing.sqf
@@ -82,12 +82,12 @@ for "_j" from 0 to (_numElements - 1) do {
 
     private _relativeWind = (_heli getVariable "fza_sfmplus_velModelSpace") vectorMultiply -1.0;
 
-    //private _fromAeroCenterToCOM = _e vectorDiff _heliCOM;
-    //private _angularVel          = (_heli getVariable "fza_sfmplus_angVelModelSpace");
+    private _fromAeroCenterToCOM = _e vectorDiff _heliCOM;
+    private _angularVel          = (_heli getVariable "fza_sfmplus_angVelModelSpace");
 
-    //private _localRelWind = (vectorNormalized _angularVel) vectorCrossProduct (vectorNormalized _fromAeroCenterToCOM);
-    //_localRelWind         = _localRelWind vectorMultiply -((vectorMagnitude _angularVel) * (vectorMagnitude _fromAeroCenterToCOM));
-    //_relativeWind         = _relativeWind vectorAdd _localRelWind;
+    private _localRelWind = (vectorNormalized _angularVel) vectorCrossProduct (vectorNormalized _fromAeroCenterToCOM);
+    _localRelWind         = _localRelWind vectorMultiply -((vectorMagnitude _angularVel) * (vectorMagnitude _fromAeroCenterToCOM));
+    _relativeWind         = _relativeWind vectorAdd _localRelWind;
 
     #ifdef __A3_DEBUG__
     [_heli, _e vectorDiff (vectorNormalized _relativeWind), _e, "red"] call fza_fnc_debugDrawLine;

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_sfmplus/functions/aero/fn_aeroWing.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_sfmplus/functions/aero/fn_aeroWing.sqf
@@ -82,12 +82,12 @@ for "_j" from 0 to (_numElements - 1) do {
 
     private _relativeWind = (_heli getVariable "fza_sfmplus_velModelSpace") vectorMultiply -1.0;
 
-    private _fromAeroCenterToCOM = _e vectorDiff _heliCOM;
-    private _angularVel          = (_heli getVariable "fza_sfmplus_angVelModelSpace");
+    //private _fromAeroCenterToCOM = _e vectorDiff _heliCOM;
+    //private _angularVel          = (_heli getVariable "fza_sfmplus_angVelModelSpace");
 
-    private _localRelWind = (vectorNormalized _angularVel) vectorCrossProduct (vectorNormalized _fromAeroCenterToCOM);
-    _localRelWind         = _localRelWind vectorMultiply -((vectorMagnitude _angularVel) * (vectorMagnitude _fromAeroCenterToCOM));
-    _relativeWind         = _relativeWind vectorAdd _localRelWind;
+    //private _localRelWind = (vectorNormalized _angularVel) vectorCrossProduct (vectorNormalized _fromAeroCenterToCOM);
+    //_localRelWind         = _localRelWind vectorMultiply -((vectorMagnitude _angularVel) * (vectorMagnitude _fromAeroCenterToCOM));
+    //_relativeWind         = _relativeWind vectorAdd _localRelWind;
 
     #ifdef __A3_DEBUG__
     [_heli, _e vectorDiff (vectorNormalized _relativeWind), _e, "red"] call fza_fnc_debugDrawLine;

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_sfmplus/functions/core/fn_coreConfig.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_sfmplus/functions/core/fn_coreConfig.sqf
@@ -23,7 +23,9 @@ fza_sfmplus_movingAverageSize = 10;
 fza_sfmplus_liftLossTimer     = 0;
 
 _heli setVariable ["fza_sfmplus_cyclicFwdAft",       0.0];
+_heli setVariable ["fza_sfmplus_cyclicPitchValue",   0.0];
 _heli setVariable ["fza_sfmplus_cyclicLeftRight",    0.0];
+_heli setVariable ["fza_sfmplus_cyclicRollValue",    0.0];
 _heli setVariable ["fza_sfmplus_pedalLeftRight",     0.0];
 _heli setVariable ["fza_sfmplus_collectiveOutput",   0.0];
 _heli setVariable ["fza_sfmplus_collectivePrevious", 0.0];
@@ -48,6 +50,9 @@ _heli setVariable ["fza_sfmplus_velWorldSpaceY_avg",  [fza_sfmplus_movingAverage
 _heli setVariable ["fza_sfmplus_velWorldSpaceZ_avg",  [fza_sfmplus_movingAverageSize] call fza_sfmplus_fnc_smoothAverageInit];
 _heli setVariable ["fza_sfmplus_velClimb",            0.0];
 _heli setVariable ["fza_sfmplus_angVelModelSpace",    [0.0,0.0,0.0]];
+//_heli setVariable ["fza_sfmplus_angVelWorldSpaceX_avg", [fza_sfmplus_movingAverageSize] call fza_sfmplus_fnc_smoothAverageInit];
+//_heli setVariable ["fza_sfmplus_angVelWorldSpaceY_avg", [fza_sfmplus_movingAverageSize] call fza_sfmplus_fnc_smoothAverageInit];
+//_heli setVariable ["fza_sfmplus_angVelWorldSpaceZ_avg", [fza_sfmplus_movingAverageSize] call fza_sfmplus_fnc_smoothAverageInit];
 _heli setVariable ["fza_sfmplus_angVelWorldSpace",    [0.0,0.0,0.0]];
 
 _heli setVariable ["fza_sfmplus_velX_prev",         0.0];
@@ -102,7 +107,7 @@ _heli setVariable ["fza_sfmplus_pid_sas_roll",       [0.0450, 0.00002, 0.0100] c
 _heli setVariable ["fza_sfmplus_pid_sas_yaw",        [0.0000, 0.00000, 0.0000] call fza_fnc_pidCreate];
 
 //Aerodynamic State Variables
-_heli setVariable ["fza_sfmplus_aero_alpha",         0.0];
+_heli setVariable ["fza_sfmplus_aero_alpha_deg",         0.0];
 _heli setVariable ["fza_sfmplus_aero_beta_deg",      0.0];
 _heli setVariable ["fza_sfmplus_aero_beta_g",        0.0];
 _heli setVariable ["fza_sfmplus_aero_gamma",         0.0];

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_sfmplus/functions/engine/fn_engine.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_sfmplus/functions/engine/fn_engine.sqf
@@ -90,10 +90,19 @@ switch (_engState) do {
 		_engPctNG = [_engPctNG, 0.0, _deltaTime] call BIS_fnc_lerp;
 		//Np
         if (_isAutorotating) then {
-            private _autoNp = linearConversion[0.0, 0.5, _collectiveOutput, 1.10, 0.0, true];
+            private _autoNp = 0.0;
+            if (_collectiveOutput > 0.295) then {
+                _autoNp = linearConversion[1.0, 0.295, _collectiveOutput, 0.0, 0.78, true];
+            };
+            if (_collectiveOutput <= 0.295 && _collectiveOutput > 0.10) then {
+                _autoNp = linearConversion[0.295, 0.100, _collectiveOutput, 1.01, 1.05, true];
+            };
+            if (_collectiveOutput <= 0.10) then {
+                _autoNp = linearConversion[0.100, 0.0, _collectiveOutput, 1.05, 1.15, true];
+            };
             _engPctNP       = [_engPctNP, _autoNp, _deltaTime] call BIS_fnc_lerp;
         } else {
-		    _engPctNP = [_engPctNP, 0.0, _deltaTime] call BIS_fnc_lerp;
+		    _engPctNP = [_engPctNP, 0.0, (1.0 / 2.0) * _deltaTime] call BIS_fnc_lerp;
         };
 		//Tq
 		_engPctTQ = [_engPctTQ, 0.0, _deltaTime] call BIS_fnc_lerp;
@@ -139,8 +148,8 @@ switch (_engState) do {
             _droopFactor    = [_droopFactor, -1.0, 0.0] call BIS_fnc_clamp;
             //Autorotation handler
             if (_isAutorotating) then { 
-                private _autoNp = 1.01;
-                if (_collectiveOutput < 0.295 && _collectiveOutput > 0.10) then {
+                private _autoNp = 0.0;
+                if (_collectiveOutput <= 0.295 && _collectiveOutput > 0.10) then {
                     _autoNp = linearConversion[0.295, 0.100, _collectiveOutput, 1.01, 1.05, true];
                 };
                 if (_collectiveOutput <= 0.10) then {

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_sfmplus/functions/engine/fn_engine.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_sfmplus/functions/engine/fn_engine.sqf
@@ -90,7 +90,7 @@ switch (_engState) do {
 		_engPctNG = [_engPctNG, 0.0, _deltaTime] call BIS_fnc_lerp;
 		//Np
         if (_isAutorotating) then {
-            private _autoNp = 0.0;
+            private _autoNp = 1.01;
             if (_collectiveOutput > 0.295) then {
                 _autoNp = linearConversion[1.0, 0.295, _collectiveOutput, 0.0, 0.78, true];
             };
@@ -148,7 +148,7 @@ switch (_engState) do {
             _droopFactor    = [_droopFactor, -1.0, 0.0] call BIS_fnc_clamp;
             //Autorotation handler
             if (_isAutorotating) then { 
-                private _autoNp = 0.0;
+                private _autoNp = 1.01;
                 if (_collectiveOutput <= 0.295 && _collectiveOutput > 0.10) then {
                     _autoNp = linearConversion[0.295, 0.100, _collectiveOutput, 1.01, 1.05, true];
                 };

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_sfmplus/functions/engine/fn_engine.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_sfmplus/functions/engine/fn_engine.sqf
@@ -139,7 +139,13 @@ switch (_engState) do {
             _droopFactor    = [_droopFactor, -1.0, 0.0] call BIS_fnc_clamp;
             //Autorotation handler
             if (_isAutorotating) then { 
-                private _autoNp = linearConversion[0.0, 0.23, _collectiveOutput, 1.10, 1.01, true];
+                private _autoNp = 1.01;
+                if (_collectiveOutput < 0.295 && _collectiveOutput > 0.10) then {
+                    _autoNp = linearConversion[0.295, 0.100, _collectiveOutput, 1.01, 1.05, true];
+                };
+                if (_collectiveOutput <= 0.10) then {
+                    _autoNp = linearConversion[0.100, 0.0, _collectiveOutput, 1.05, 1.15, true];
+                };
                 _engPctNP       = [_engPctNP, _autoNp, _deltaTime] call BIS_fnc_lerp;
             } else {
                 _engPctNP       = [_engPctNP, _engBaseNP + _droopFactor, _deltaTime] call BIS_fnc_lerp;
@@ -162,15 +168,15 @@ private _hvrTQ      = linearConversion [15.24, 1.52, _heightAGL, _hvrOGE, _hvrIG
 
 //If the engine isn't overspeed, do normal engine things
 if (!_engOverspeed) then {
-    _engPctTQ = (_heli getVariable "fza_sfmplus_reqEngTorque") / 481.0;
+    private _rtrTq = (_heli getVariable "fza_sfmplus_reqEngTorque") / 481.109;
     if (_isSingleEng) then {
         if (_engPowerLeverState in ["OFF", "IDLE"]) then {
             _engPctTQ = 0.0;
         } else {
-            _engPctTQ = _engPctTQ;
+            _engPctTQ = _rtrTq;
         };
     } else {
-        _engPctTQ = _engPctTQ / 2.0;
+        _engPctTQ = _rtrTq / 2.0;
     };
 } else {
     //If the engine is overspeeding, then do over speed things

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_sfmplus/functions/fmc/fn_fmc.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_sfmplus/functions/fmc/fn_fmc.sqf
@@ -39,4 +39,6 @@ if (!(_heli getVariable "fza_ah64_fmcCollOn")) then {
     _altHoldCollOut = 0.0;
 };
 
+//_SASPitchOutput = 0.0; _SASRollOutput = 0.0; _SASYawOutput = 0.0;
+
 [_attHoldCycPitchOut + _SASPitchOutput, _attHoldCycRollOut + _SASRollOutput, _hdgHoldPedalYawOut + _SASYawOutput, _altHoldCollOut];

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_sfmplus/functions/fmc/fn_fmcForceTrimSet.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_sfmplus/functions/fmc/fn_fmcForceTrimSet.sqf
@@ -1,7 +1,7 @@
 params ["_heli"];
 #include "\fza_ah64_sfmplus\headers\core.hpp"
 
-if (fza_ah64_sfmPlusControlScheme == HOTAS) then {
+if (fza_ah64_sfmPlusControlScheme == HOTAS || fza_ah64_sfmPlusControlScheme == MOUSE) then {
     //Cyclic pitch trim
     private _curCyclicFwdAft  = (_heli getVariable "fza_sfmplus_cyclicFwdAft");
     private _prevCyclicFwdAft = _heli getVariable "fza_ah64_forceTrimPosPitch";

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_sfmplus/functions/fn_calculateAeroValues.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_sfmplus/functions/fn_calculateAeroValues.sqf
@@ -48,10 +48,10 @@ private _totVelY  = _totVel # 1;
 private _totVelZ  = _totVel # 2;
 
 //Alpha is the angle between the helicopters forward velocity and vertical velocity
-private _alpha    = if (_totVelY == 0) then { 0.0; } else { atan (_totVelZ / _totVelY); };
+private _alpha_deg = if (_totVelY == 0) then { 0.0; } else { atan (_totVelZ / _totVelY); };
 //Beta, or sideslip, is the difference betwen the helicopters sideward velocity and the total velocity
-private _beta_deg = if ((vectorMagnitude _totVel) == 0.0) then { 0.0; } else { asin (_totVelX / (vectorMagnitude _totVel)); };
-private _beta_g   = ((vectorMagnitude _totVel) * (sin _beta_deg)) / GRAVITY;
+private _beta_deg  = if ((vectorMagnitude _totVel) == 0.0) then { 0.0; } else { asin (_totVelX / (vectorMagnitude _totVel)); };
+private _beta_g    = ((vectorMagnitude _totVel) * (sin _beta_deg)) / GRAVITY;
 
 //private _beta_degAccel = (-9.806 * (tan _beta_deg)) / 9.8
 //systemChat format ["Sidelsip = %1 - Beta = %2", _beta_deg, _beta_g];
@@ -59,7 +59,7 @@ private _beta_g   = ((vectorMagnitude _totVel) * (sin _beta_deg)) / GRAVITY;
 private _gamma    = if (_modelVelY == 0) then { 0.0; } else { asin (_totVelZ / _modelVelY); };
 if ([_gamma] call fza_sfmplus_fnc_isNAN || [_gamma] call fza_sfmplus_fnc_isINF) then { _gamma = 0.0; };
 
-_heli setVariable ["fza_sfmplus_aero_alpha",    _alpha,    true];
-_heli setVariable ["fza_sfmplus_aero_beta_deg", _beta_deg, true];
-_heli setVariable ["fza_sfmplus_aero_beta_g",   _beta_g,   true];
-_heli setVariable ["fza_sfmplus_aero_gamma",    _gamma,    true];
+_heli setVariable ["fza_sfmplus_aero_alpha_deg", _alpha_deg, true];
+_heli setVariable ["fza_sfmplus_aero_beta_deg",  _beta_deg,  true];
+_heli setVariable ["fza_sfmplus_aero_beta_g",    _beta_g,    true];
+_heli setVariable ["fza_sfmplus_aero_gamma",     _gamma,     true];

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_sfmplus/functions/fn_getInput.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_sfmplus/functions/fn_getInput.sqf
@@ -50,40 +50,36 @@ _cyclicFwdAft                = [_heli, "pitch", _cyclicFwdAft, _inputLagValue] c
 //Cyclic roll
 private _cyclicLeftRight     = (_heli animationSourcePhase "cyclicAside") * -1.0;
 _cyclicLeftRight             = [_heli, "roll", _cyclicLeftRight, _inputLagValue] call fza_sfmplus_fnc_actuator;
-_cyclicLeftRight             = [_cyclicLeftRight, -1.0, 1.0] call BIS_fnc_clamp;
 
 if (fza_ah64_sfmPlusControlScheme == KEYBOARD) then {
     //Cyclic Pitch
     private _cyclicPitchValue = _heli getVariable "fza_sfmplus_cyclicPitchValue";
     if (_cyclicFwdAft > 0.1) then {
-        _cyclicPitchValue = _cyclicPitchValue + ((1.0 / 1.0) * _deltaTime);
-        systemChat format ["_cyclicFwdAft > 0.1!"];
+        _cyclicPitchValue = _cyclicPitchValue + ((1.0 / 3.0) * _deltaTime);
     };
     if (_cyclicFwdAft < -0.1) then {
-        _cyclicPitchValue = _cyclicPitchValue - ((1.0 / 1.0) * _deltaTime);
-        systemChat format ["_cyclicFwdAft < 0.1!"];
+        _cyclicPitchValue = _cyclicPitchValue - ((1.0 / 3.0) * _deltaTime);
     };
     systemChat format ["_cyclicPitchValue = %1 -- _cyclicFwdAft = %2", _cyclicPitchValue, _cyclicFwdAft];
     //Set pitch
     _cyclicFwdAft         = [_cyclicPitchValue, -1.0, 1.0] call BIS_fnc_clamp;
-    _heli setVariable ["fza_sfmplus_cyclicPitchValue", _cyclicPitchValue];
+    _heli setVariable ["fza_sfmplus_cyclicPitchValue", [_cyclicPitchValue, -1.0, 1.0] call BIS_fnc_clamp];
+    
     //Cyclic Roll
-    //private _cyclicRollValue = _heli getVariable "fza_sfmplus_cyclicRollValue";
-    //if (_cyclicLeftRight > 0.1) then {
-    //    _cyclicRollValue = _cyclicRollValue + ((1.0 / 6.0) * _deltaTime);
-    //    systemChat format ["_cyclicLeftRight > 0.1!"];
-    //};
-    //if (_cyclicLeftRight < -0.1) then {
-    //    _cyclicRollValue = _cyclicRollValue - ((1.0 / 6.0) * _deltaTime);
-    //    systemChat format ["_cyclicLeftRight < 0.1!"];
-    //};
-    //systemChat format ["_cyclicRollValue = %1 -- _cyclicLeftRight = %2", _cyclicRollValue, _cyclicLeftRight];
-    ////Set roll
-    //_cyclicLeftRight     = [_cyclicRollValue, -1.0, 1.0] call BIS_fnc_clamp;
-    //_heli setVariable ["fza_sfmplus_cyclicRollValue", _cyclicRollValue];
+    private _cyclicRollValue = _heli getVariable "fza_sfmplus_cyclicRollValue";
+    if (_cyclicLeftRight > 0.1) then {
+        _cyclicRollValue = _cyclicRollValue + ((1.0 / 3.0) * _deltaTime);
+    };
+    if (_cyclicLeftRight < -0.1) then {
+        _cyclicRollValue = _cyclicRollValue - ((1.0 / 3.0) * _deltaTime);
+    };
+    systemChat format ["_cyclicRollValue = %1 -- _cyclicLeftRight = %2", _cyclicRollValue, _cyclicLeftRight];
+    //Set roll
+    _cyclicLeftRight     = [_cyclicRollValue, -1.0, 1.0] call BIS_fnc_clamp;
+    _heli setVariable ["fza_sfmplus_cyclicRollValue", [_cyclicRollValue, -1.0, 1.0] call BIS_fnc_clamp];
 } else {;
     _cyclicFwdAft        = [_cyclicFwdAft, -1.0, 1.0] call BIS_fnc_clamp;
-    //_cyclicLeftRight     = [_cyclicLeftRight, -1.0, 1.0] call BIS_fnc_clamp;
+    _cyclicLeftRight     = [_cyclicLeftRight, -1.0, 1.0] call BIS_fnc_clamp;
 };
 //Pedals
 private _pedalLeftRight      = (inputAction "HeliRudderRight") - (inputAction "HeliRudderLeft");

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_sfmplus/functions/fn_getInput.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_sfmplus/functions/fn_getInput.sqf
@@ -60,7 +60,6 @@ if (fza_ah64_sfmPlusControlScheme == KEYBOARD) then {
     if (_cyclicFwdAft < -0.1) then {
         _cyclicPitchValue = _cyclicPitchValue - ((1.0 / 3.0) * _deltaTime);
     };
-    systemChat format ["_cyclicPitchValue = %1 -- _cyclicFwdAft = %2", _cyclicPitchValue, _cyclicFwdAft];
     //Set pitch
     _cyclicFwdAft         = [_cyclicPitchValue, -1.0, 1.0] call BIS_fnc_clamp;
     _heli setVariable ["fza_sfmplus_cyclicPitchValue", [_cyclicPitchValue, -1.0, 1.0] call BIS_fnc_clamp];
@@ -73,7 +72,6 @@ if (fza_ah64_sfmPlusControlScheme == KEYBOARD) then {
     if (_cyclicLeftRight < -0.1) then {
         _cyclicRollValue = _cyclicRollValue - ((1.0 / 3.0) * _deltaTime);
     };
-    systemChat format ["_cyclicRollValue = %1 -- _cyclicLeftRight = %2", _cyclicRollValue, _cyclicLeftRight];
     //Set roll
     _cyclicLeftRight     = [_cyclicRollValue, -1.0, 1.0] call BIS_fnc_clamp;
     _heli setVariable ["fza_sfmplus_cyclicRollValue", [_cyclicRollValue, -1.0, 1.0] call BIS_fnc_clamp];

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_sfmplus/functions/fn_getInput.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_sfmplus/functions/fn_getInput.sqf
@@ -46,15 +46,45 @@ private _apuOn              = _heli getVariable "fza_systems_apuOn";
 //Cyclic pitch
 private _cyclicFwdAft        = _heli animationSourcePhase "cyclicForward";
 _cyclicFwdAft                = [_heli, "pitch", _cyclicFwdAft, _inputLagValue] call fza_sfmplus_fnc_actuator;
-_cyclicFwdAft                = [_cyclicFwdAft, -1.0, 1.0] call BIS_fnc_clamp;
-//private _cyclicFwdAftTrim    = _heli getVariable "fza_ah64_forceTrimPosPitch";
 
 //Cyclic roll
 private _cyclicLeftRight     = (_heli animationSourcePhase "cyclicAside") * -1.0;
 _cyclicLeftRight             = [_heli, "roll", _cyclicLeftRight, _inputLagValue] call fza_sfmplus_fnc_actuator;
 _cyclicLeftRight             = [_cyclicLeftRight, -1.0, 1.0] call BIS_fnc_clamp;
-//private _cyclicLeftRightTrim = _heli getVariable "fza_ah64_forceTrimPosRoll";
 
+if (fza_ah64_sfmPlusControlScheme == KEYBOARD) then {
+    //Cyclic Pitch
+    private _cyclicPitchValue = _heli getVariable "fza_sfmplus_cyclicPitchValue";
+    if (_cyclicFwdAft > 0.1) then {
+        _cyclicPitchValue = _cyclicPitchValue + ((1.0 / 1.0) * _deltaTime);
+        systemChat format ["_cyclicFwdAft > 0.1!"];
+    };
+    if (_cyclicFwdAft < -0.1) then {
+        _cyclicPitchValue = _cyclicPitchValue - ((1.0 / 1.0) * _deltaTime);
+        systemChat format ["_cyclicFwdAft < 0.1!"];
+    };
+    systemChat format ["_cyclicPitchValue = %1 -- _cyclicFwdAft = %2", _cyclicPitchValue, _cyclicFwdAft];
+    //Set pitch
+    _cyclicFwdAft         = [_cyclicPitchValue, -1.0, 1.0] call BIS_fnc_clamp;
+    _heli setVariable ["fza_sfmplus_cyclicPitchValue", _cyclicPitchValue];
+    //Cyclic Roll
+    //private _cyclicRollValue = _heli getVariable "fza_sfmplus_cyclicRollValue";
+    //if (_cyclicLeftRight > 0.1) then {
+    //    _cyclicRollValue = _cyclicRollValue + ((1.0 / 6.0) * _deltaTime);
+    //    systemChat format ["_cyclicLeftRight > 0.1!"];
+    //};
+    //if (_cyclicLeftRight < -0.1) then {
+    //    _cyclicRollValue = _cyclicRollValue - ((1.0 / 6.0) * _deltaTime);
+    //    systemChat format ["_cyclicLeftRight < 0.1!"];
+    //};
+    //systemChat format ["_cyclicRollValue = %1 -- _cyclicLeftRight = %2", _cyclicRollValue, _cyclicLeftRight];
+    ////Set roll
+    //_cyclicLeftRight     = [_cyclicRollValue, -1.0, 1.0] call BIS_fnc_clamp;
+    //_heli setVariable ["fza_sfmplus_cyclicRollValue", _cyclicRollValue];
+} else {;
+    _cyclicFwdAft        = [_cyclicFwdAft, -1.0, 1.0] call BIS_fnc_clamp;
+    //_cyclicLeftRight     = [_cyclicLeftRight, -1.0, 1.0] call BIS_fnc_clamp;
+};
 //Pedals
 private _pedalLeftRight      = (inputAction "HeliRudderRight") - (inputAction "HeliRudderLeft");
 _pedalLeftRight              = [_heli, "yaw", _pedalLeftRight, _inputLagValue] call fza_sfmplus_fnc_actuator;

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_sfmplus/functions/fn_getInput.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_sfmplus/functions/fn_getInput.sqf
@@ -51,30 +51,36 @@ _cyclicFwdAft                = [_heli, "pitch", _cyclicFwdAft, _inputLagValue] c
 private _cyclicLeftRight     = (_heli animationSourcePhase "cyclicAside") * -1.0;
 _cyclicLeftRight             = [_heli, "roll", _cyclicLeftRight, _inputLagValue] call fza_sfmplus_fnc_actuator;
 
-if (fza_ah64_sfmPlusControlScheme == KEYBOARD) then {
+if (fza_ah64_sfmPlusControlScheme == KEYBOARD && fza_ah64_sfmplusEnableKbPitchTrim) then {
     //Cyclic Pitch
+    private _divisor  = 3;
+    private _inputVal = 0.001;
+
     private _cyclicPitchValue = _heli getVariable "fza_sfmplus_cyclicPitchValue";
     if (_cyclicFwdAft > 0.1) then {
-        _cyclicPitchValue = _cyclicPitchValue + ((1.0 / 3.0) * _deltaTime);
+        _cyclicPitchValue = _cyclicPitchValue + ((1 / _divisor) * _deltaTime);
     };
     if (_cyclicFwdAft < -0.1) then {
-        _cyclicPitchValue = _cyclicPitchValue - ((1.0 / 3.0) * _deltaTime);
+        _cyclicPitchValue = _cyclicPitchValue - ((1 / _divisor) * _deltaTime);
     };
     //Set pitch
+    _cyclicPitchValue     = (round (_cyclicPitchValue / _inputVal)) * _inputVal;
     _cyclicFwdAft         = [_cyclicPitchValue, -1.0, 1.0] call BIS_fnc_clamp;
     _heli setVariable ["fza_sfmplus_cyclicPitchValue", [_cyclicPitchValue, -1.0, 1.0] call BIS_fnc_clamp];
     
     //Cyclic Roll
-    private _cyclicRollValue = _heli getVariable "fza_sfmplus_cyclicRollValue";
-    if (_cyclicLeftRight > 0.1) then {
-        _cyclicRollValue = _cyclicRollValue + ((1.0 / 3.0) * _deltaTime);
-    };
-    if (_cyclicLeftRight < -0.1) then {
-        _cyclicRollValue = _cyclicRollValue - ((1.0 / 3.0) * _deltaTime);
-    };
+    //private _cyclicRollValue = _heli getVariable "fza_sfmplus_cyclicRollValue";
+    //if (_cyclicLeftRight > 0.1) then {
+    //    _cyclicRollValue = _cyclicRollValue + ((1 / _divisor) * _deltaTime);
+    //};
+    //if (_cyclicLeftRight < -0.1) then {
+    //    _cyclicRollValue = _cyclicRollValue - ((1 / _divisor) * _deltaTime);
+    //};
     //Set roll
-    _cyclicLeftRight     = [_cyclicRollValue, -1.0, 1.0] call BIS_fnc_clamp;
-    _heli setVariable ["fza_sfmplus_cyclicRollValue", [_cyclicRollValue, -1.0, 1.0] call BIS_fnc_clamp];
+    //_cyclicRollValue     = (round (_cyclicRollValue / _inputVal)) * _inputVal;
+    //_cyclicLeftRight     = [_cyclicRollValue, -1.0, 1.0] call BIS_fnc_clamp;
+    //_heli setVariable ["fza_sfmplus_cyclicRollValue", [_cyclicRollValue, -1.0, 1.0] call BIS_fnc_clamp];
+    _cyclicLeftRight     = [_cyclicLeftRight, -1.0, 1.0] call BIS_fnc_clamp;
 } else {;
     _cyclicFwdAft        = [_cyclicFwdAft, -1.0, 1.0] call BIS_fnc_clamp;
     _cyclicLeftRight     = [_cyclicLeftRight, -1.0, 1.0] call BIS_fnc_clamp;

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_sfmplus/functions/fn_getVelocities.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_sfmplus/functions/fn_getVelocities.sqf
@@ -64,7 +64,17 @@ private _velWorldSpace         = [_velWorldSpaceX, _velWorldSpaceY, _velWorldSpa
 //Climb velocity
 private _velClimb              = (_velWorldSpace select 2) * MPS_TO_FPM;
 //Angular velocity in model space
-private _angVelModelSpace      = angularVelocityModelSpace _heli;
+//private _angVelModelSpaceX_avg    = _heli getVariable "fza_sfmplus_angVelModelSpaceX_avg";
+//private _angVelModelSpaceY_avg    = _heli getVariable "fza_sfmplus_angVelModelSpaceY_avg";
+//private _angVelModelSpaceZ_avg    = _heli getVariable "fza_sfmplus_angVelModelSpaceZ_avg";
+
+private _angVelModelSpaceX     = angularVelocityModelSpace _heli select 0;
+//_angVelModelSpaceX             = [_angVelModelSpaceX_avg, _angVelModelSpaceX] call fza_sfmplus_fnc_getSmoothAverage;
+private _angVelModelSpaceY     = angularVelocityModelSpace _heli select 1;
+//_angVelModelSpaceY             = [_angVelModelSpaceY_avg, _angVelModelSpaceY] call fza_sfmplus_fnc_getSmoothAverage;
+private _angVelModelSpaceZ     = angularVelocityModelSpace _heli select 2;
+//_angVelModelSpaceZ             = [_angVelModelSpaceZ_avg, _angVelModelSpaceZ] call fza_sfmplus_fnc_getSmoothAverage;
+private _angVelModelSpace      = [_angVelModelSpaceX, _angVelModelSpaceY, _angVelModelSpaceZ];
 //Angular velocity in world space
 private _angVelWorldSpace      = angularVelocity _heli;
 

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_sfmplus/functions/mass/fn_massUpdate.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_sfmplus/functions/mass/fn_massUpdate.sqf
@@ -103,15 +103,15 @@ _curLongCG  = _curLongMom / _curMass;
 _curLatMom  = _stn1LatMom + _stn2LatMom + _stn3LatMom + _stn4LatMom;
 _curLatCG   = _curLatMom / _curMass;
 
-if (fza_ah64_sfmPlusControlScheme == KEYBOARD || fza_ah64_sfmPlusControlScheme == MOUSE) then {
-    _heli setCenterOfMass [0.0, 2.06, -1.34];
-} else {
+//if (fza_ah64_sfmPlusControlScheme == KEYBOARD || fza_ah64_sfmPlusControlScheme == MOUSE) then {
+//    _heli setCenterOfMass [0.0, 2.06, -1.34];
+//} else {
     _heli setCenterOfMass [_curLatCG, 7.12 - _curLongCG, -1.34];
-};
+//};
 //systemChat format ["Total Mass = %1 lbs (%2 kg) -- Total Moment = %3 -- Long CG = %4 in -- Lat CG = %5 in", (_curMass * 2.20462) toFixed 1, _curMass toFixed 1, _curLongMom toFixed 3, (_curLongCG * 39.3701) toFixed 1, (_curLatCG * 39.3701) toFixed 1];
 //systemChat format ["Center of Mass = %1", getCenterOfMass _heli];
 
-//_curMass = MASS;//8165;
+//_curMass = 8165;//MASS;//8165;
 _heli setMass _curMass;
 
 _heli setVariable ["fza_sfmplus_GWT", _curMass,   true];


### PR DESCRIPTION
+ Adds sticky cyclic (pitch only)
+ Updates Rotor Model (previous implementation doubled the thrust, however this restricts the FM to Sea Level and Standard day at the moment)
+ Fix stabilator schedule (result of collective range being fixed)
+ Fixes collective input range (due to Updated Rotor Model)
+ Fixes fuselage drag (uses fuselage AoA and updated fuselage torque table)
+ Enables force trim for mouse users
+ Updated autorotation behavior (result of updated rotor model)