### PR TITLE
HeliSim Bug Fixes for v2.2.2

### DIFF
--- a/@AH-64D Apache Longbow/Addons/fza_ah64_controls/XEH_preInit.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_controls/XEH_preInit.sqf
@@ -59,6 +59,24 @@ private _projName = "AH-64D Official Project";
 ] call CBA_fnc_addSetting;
 
 [
+    "fza_sfmplus_cyclicCenterTrimMode",
+    "CHECKBOX",
+    ["Cyclic Center Trim Mode", "When enabled, the cyclic is locked out until re-centered."],
+    [_projName, "Flight model"],
+    [false],
+    2
+] call CBA_fnc_addSetting;
+
+[
+    "fza_sfmplus_pedalCenterTrimMode",
+    "CHECKBOX",
+    ["Pedal Center Trim Mode", "When enabled, the pedals are locked out until re-centered."],
+    [_projName, "Flight model"],
+    [false],
+    2
+] call CBA_fnc_addSetting;
+
+[
     "fza_ah64_sfmPlusSpringlessCyclic",
     "CHECKBOX",
     ["Springless Cyclic", "When enabled, cyclic force trim is disabled. This is for users with force feedback or springless HOTAS."],
@@ -111,7 +129,6 @@ private _projName = "AH-64D Official Project";
     [false],
     2
 ] call CBA_fnc_addSetting;
-
 
 [
     "fza_ah64_sfmPlusMouseAsJoystick",

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_controls/config.cpp
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_controls/config.cpp
@@ -8,9 +8,9 @@ class CfgPatches
         weapons[] = {};
         requiredVersion = 2.10;
         requiredAddons[] = {"A3_Air_F_Beta","A3_Sounds_F","A3_Data_F", "cba_main", "cba_xeh", "fza_ah64_sfmplus", "fza_ah64_aiCrew", "fza_ah64_audio", "fza_ah64_ihadss", "fza_ah64_fcr"};
-        version = 2.2.2;
-        versionStr = "2.2.2";
-        versionAr[] = {2, 2, 2};
+        version = 2.2.3;
+        versionStr = "2.2.3";
+        versionAr[] = {2, 2, 3};
     };
 };
 class CfgAddons

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_controls/functions/core/fn_coreControlHandle.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_controls/functions/core/fn_coreControlHandle.sqf
@@ -334,6 +334,8 @@ if !(_value) then {
             _heli setVariable ["fza_ah64_hdgHoldDesiredHdg",      getDir _heli,          true];
             _heli setVariable ["fza_ah64_hdgHoldDesiredSideslip", fza_ah64_sideslip,     true];
             [_heli] call fza_sfmplus_fnc_fmcForceTrimSet;
+
+            [_heli] call fza_sfmplus_fnc_centerTrimMode;
         };
         case "fza_ah64_stickyControlInterupt": {
             _heli setVariable ["fza_sfmplus_kbStickyInterupt", false];

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_sfmplus/cfgFunctions.hpp
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_sfmplus/cfgFunctions.hpp
@@ -106,6 +106,7 @@ class CfgFunctions
         class utility {
             file = "\fza_ah64_sfmplus\functions";
             class calculateAeroValues {R;};
+            class centerTrimMode {R;};
             class getAccelerations {R;};
             class getAltitude {R;};
             class getDeltaTime {R;};

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_sfmplus/functions/core/fn_coreConfig.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_sfmplus/functions/core/fn_coreConfig.sqf
@@ -22,9 +22,8 @@ private _config = configFile >> "CfgVehicles" >> typeof _heli >> "fza_sfmplus";
 fza_sfmplus_movingAverageSize = 10;
 fza_sfmplus_liftLossTimer     = 0;
 
-_heli setVariable ["fza_sfmplus_kbStickyInterupt",      false];
-_heli getVariable ["fza_sfmplus_rollTimer",             0.0];
-_heli getVariable ["fza_sfmplus_pitchTimer",            0.0];
+_heli setVariable ["fza_sfmplus_kbStickyInterupt",     false];
+_heli setVariable ["fza_sfmplus_flightControlLockOut", false];
 
 _heli setVariable ["fza_sfmplus_cyclicFwdAft",          0.0];
 _heli setVariable ["fza_sfmplus_cyclicPitchValue",      0.0];
@@ -104,6 +103,14 @@ _heli setVariable ["fza_sfmplus_maxCtrFuelMass",     getNumber (_config >> "maxC
 _heli setVariable ["fza_sfmplus_maxAftFuelMass",     getNumber (_config >> "maxAftFuelMass")];  //1474lbs in kg
 _heli setVariable ["fza_sfmplus_maxExtFuelMass",     getNumber (_config >> "maxExtFuelMass")];     //1541lbs in kg, not yet implemented, 230gal external tank
 
+_heli setVariable ["fza_sfmplus_fmcAttHoldCycPitchOut", 0.0];
+_heli setVariable ["fza_sfmplus_fmcSasPitchOut",        0.0];
+_heli setVariable ["fza_sfmplus_fmcCttHoldCycRollOut",  0.0];
+_heli setVariable ["fza_sfmplus_fmcSasRollOut",         0.0];
+_heli setVariable ["fza_sfmplus_fmcHdgHoldPedalYawOut", 0.0];
+_heli setVariable ["fza_sfmplus_fmcSasYawOut",          0.0];
+_heli setVariable ["fza_sfmplus_fmcAltHoldCollOut",     0.0];
+
 //Position Hold
 _heli setVariable ["fza_sfmplus_pid_roll",           [0.0550, 0.0070, 0.0900] call fza_fnc_pidCreate];
 _heli setVariable ["fza_sfmplus_pid_pitch",          [0.1500, 0.0070, 0.1200] call fza_fnc_pidCreate];
@@ -117,9 +124,9 @@ _heli setVariable ["fza_sfmplus_pid_barHold",        [0.0075, 0.0001, 0.0025] ca
 _heli setVariable ["fza_sfmplus_pid_hdgHold",        [0.0750, 0.0200, 0.0050] call fza_fnc_pidCreate];
 _heli setVariable ["fza_sfmplus_pid_trnCoord",       [0.5500, 0.0400, 0.2000] call fza_fnc_pidCreate];
 //SAS Functions
-_heli setVariable ["fza_sfmplus_pid_sas_pitch",      [0.6250, 0.0250, 0.1000] call fza_fnc_pidCreate];
-_heli setVariable ["fza_sfmplus_pid_sas_roll",       [0.1250, 0.0010, 0.1000] call fza_fnc_pidCreate];
-_heli setVariable ["fza_sfmplus_pid_sas_yaw",        [0.1250, 0.0010, 0.0250] call fza_fnc_pidCreate];
+_heli setVariable ["fza_sfmplus_pid_sas_pitch",      [0.1000, 0.0000, 0.0020] call fza_fnc_pidCreate];
+_heli setVariable ["fza_sfmplus_pid_sas_roll",       [0.5000, 0.0000, 0.0020] call fza_fnc_pidCreate];
+_heli setVariable ["fza_sfmplus_pid_sas_yaw",        [0.1250, 0.0000, 0.0250] call fza_fnc_pidCreate];
 //Auto pedal
 _heli setVariable ["fza_sfmplus_pid_autoPedalHdg",   [0.1000, 0.0010, 0.0500] call fza_fnc_pidCreate];
 _heli setVariable ["fza_sfmplus_pid_autoPedalSlip",  [1.1000, 0.1500, 0.3500] call fza_fnc_pidCreate];

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_sfmplus/functions/fmc/fn_fmc.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_sfmplus/functions/fmc/fn_fmc.sqf
@@ -37,7 +37,13 @@ if (!(_heli getVariable "fza_ah64_fmcCollOn")) then {
     _altHoldCollOut = 0.0;
 };
 
-_heli setVariable ["fza_sfmplus_attHoldCycPitchOut",   _attHoldCycPitchOut + _SASPitchOutput];
-_heli setVariable ["fza_sfmplus_attHoldCycRollOut",    _attHoldCycRollOut  + _SASRollOutput];
-_heli setVariable ["fza_sfmplus_hdgHoldPedalYawOut",   _hdgHoldPedalYawOut + _SASYawOutput];
-_heli setVariable ["fza_sfmplus_altHoldCollOut",       _altHoldCollOut];
+_heli setVariable ["fza_sfmplus_fmcAttHoldCycPitchOut", _attHoldCycPitchOut];
+_heli setVariable ["fza_sfmplus_fmcSasPitchOut",        _SASPitchOutput];
+
+_heli setVariable ["fza_sfmplus_fmcAttHoldCycRollOut",  _attHoldCycRollOut];
+_heli setVariable ["fza_sfmplus_fmcSasRollOut",         _SASRollOutput];
+
+_heli setVariable ["fza_sfmplus_fmcHdgHoldPedalYawOut", _hdgHoldPedalYawOut];
+_heli setVariable ["fza_sfmplus_fmcSasYawOut",          _SASYawOutput];
+
+_heli setVariable ["fza_sfmplus_fmcAltHoldCollOut",     _altHoldCollOut];

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_sfmplus/functions/fmc/fn_fmcSAS.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_sfmplus/functions/fmc/fn_fmcSAS.sqf
@@ -44,7 +44,6 @@ if (!(_heli getVariable "fza_ah64_forceTrimInterupted")) then {
     [_pidSASYaw]   call fza_fnc_pidReset;
  };
 
-
 //systemChat format ["Pitch SAS = %1 -- Roll SAS = %2", _SASPitchOutput, _SASRollOutput];
 //systemChat format ["_cyclicFwdAft = %1 -- _cyclicLeftRight = %2 -- _pedalLeftRight = %3", _heli getVariable "fza_sfmplus_cyclicFwdAft" toFixed 2, _heli getVariable "fza_sfmplus_cyclicLeftRight" toFixed 2, _heli getVariable "fza_sfmplus_pedalLeftRight" toFixed 2];
 //systemChat format ["_angVelX = %1 - _angVelY = %2 - _angVelZ = %3", _angVelX, _angVelY, _angVelZ];

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_sfmplus/functions/fn_centerTrimMode.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_sfmplus/functions/fn_centerTrimMode.sqf
@@ -1,3 +1,5 @@
+#include "\fza_ah64_sfmplus\headers\core.hpp"
+
 params ["_heli"];
 
 if (!(currentPilot _heli == player) || !(local _heli)) exitWith {};
@@ -7,19 +9,19 @@ private _cyclicLeftRight = _heli getVariable "fza_sfmplus_cyclicLeftRight";
 private _pedalLeftRight  = _heli getVariable "fza_sfmplus_pedalLeftRight";
 
 if (fza_sfmplus_cyclicCenterTrimMode) then {
-    while {_cyclicFwdAft > 0.01 || _cyclicFwdAft < -0.01} do {
+    while {_cyclicFwdAft > CENTER_TRIM_VAL || _cyclicFwdAft < -CENTER_TRIM_VAL} do {
         //systemChat format ["Pitch Locked out! Return Pitch to Center!"];
         _heli setVariable ["fza_sfmplus_flightControlLockOut", true];
     };
 
-    while {_cyclicLeftRight > 0.01 || _cyclicLeftRight < -0.01} do {
+    while {_cyclicLeftRight > CENTER_TRIM_VAL || _cyclicLeftRight < -CENTER_TRIM_VAL} do {
         //systemChat format ["Roll Locked out! Return Roll to Center!"];
         _heli setVariable ["fza_sfmplus_flightControlLockOut", true];
     };
 };
 
 if (fza_sfmplus_pedalCenterTrimMode) then {
-    while {_pedalLeftRight > 0.01 || _pedalLeftRight < -0.01} do {
+    while {_pedalLeftRight > CENTER_TRIM_VAL || _pedalLeftRight < -CENTER_TRIM_VAL} do {
         //systemChat format ["Yaw Locked out! Return Yaw to Center!"];
         _heli setVariable ["fza_sfmplus_flightControlLockOut", true];
     };

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_sfmplus/functions/fn_centerTrimMode.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_sfmplus/functions/fn_centerTrimMode.sqf
@@ -1,0 +1,26 @@
+params ["_heli"];
+
+if (!(currentPilot _heli == player) || !(local _heli)) exitWith {};
+
+private _cyclicFwdAft    = _heli getVariable "fza_sfmplus_cyclicFwdAft";
+private _cyclicLeftRight = _heli getVariable "fza_sfmplus_cyclicLeftRight";
+private _pedalLeftRight  = _heli getVariable "fza_sfmplus_pedalLeftRight";
+
+if (fza_sfmplus_cyclicCenterTrimMode) then {
+    while {_cyclicFwdAft > 0.01 || _cyclicFwdAft < -0.01} do {
+        //systemChat format ["Pitch Locked out! Return Pitch to Center!"];
+        _heli setVariable ["fza_sfmplus_flightControlLockOut", true];
+    };
+
+    while {_cyclicLeftRight > 0.01 || _cyclicLeftRight < -0.01} do {
+        //systemChat format ["Roll Locked out! Return Roll to Center!"];
+        _heli setVariable ["fza_sfmplus_flightControlLockOut", true];
+    };
+};
+
+if (fza_sfmplus_pedalCenterTrimMode) then {
+    while {_pedalLeftRight > 0.01 || _pedalLeftRight < -0.01} do {
+        //systemChat format ["Yaw Locked out! Return Yaw to Center!"];
+        _heli setVariable ["fza_sfmplus_flightControlLockOut", true];
+    };
+};

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_sfmplus/functions/fn_getInput.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_sfmplus/functions/fn_getInput.sqf
@@ -45,6 +45,7 @@ private _keyboardTimeScalar = 1.0 / 3.00;
 private _keyboardLimitVal   = 1.0;
 
 private _kbStickyInterupt   = _heli getVariable "fza_sfmplus_kbStickyInterupt";
+private _fltControlLockout  = _heli getVariable "fza_sfmplus_flightControlLockOut";
 private _collectiveOutput   = _heli getVariable "fza_sfmplus_collectiveOutput";
 private _collectivePrevious = _heli getVariable "fza_sfmplus_collectivePrevious";
 private _collectiveValue    = _heli getVariable "fza_sfmplus_collectiveValue";
@@ -202,6 +203,23 @@ if (fza_ah64_sfmPlusAutoPedal) then {
     _heli setVariable ["fza_sfmPlus_autoPedalHdg",     _desiredHdg, true];
 };
 
+if (_fltControlLockout) then {
+    if (
+        (_cyclicFwdAft    < 0.05 && _cyclicFwdAft    > -0.05) &&
+        (_cyclicLeftRight < 0.05 && _cyclicLeftRight > -0.05) &&
+        (_pedalLeftRight  < 0.05 && _pedalLeftRight  > -0.05)
+       ) then {
+            _heli setVariable ["fza_sfmplus_flightControlLockOut", false];
+       };
+       if (fza_sfmplus_cyclicCenterTrimMode) then {
+            _cyclicFwdAft    = 0.0;
+            _cyclicLeftRight = 0.0;
+       };
+
+       if (fza_sfmplus_pedalCenterTrimMode) then {
+            _pedalLeftRight  = 0.0;
+       };
+};
 _cyclicFwdAft    = [_heli, "pitch", _cyclicFwdAft,    _inputLagValue] call fza_sfmplus_fnc_actuator;
 _cyclicLeftRight = [_heli, "roll",  _cyclicLeftRight, _inputLagValue] call fza_sfmplus_fnc_actuator;
 _pedalLeftRight  = [_heli, "yaw",   _pedalLeftRight,  _inputLagValue] call fza_sfmplus_fnc_actuator;

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_sfmplus/functions/fn_getInput.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_sfmplus/functions/fn_getInput.sqf
@@ -205,9 +205,9 @@ if (fza_ah64_sfmPlusAutoPedal) then {
 
 if (_fltControlLockout) then {
     if (
-        (_cyclicFwdAft    < 0.05 && _cyclicFwdAft    > -0.05) &&
-        (_cyclicLeftRight < 0.05 && _cyclicLeftRight > -0.05) &&
-        (_pedalLeftRight  < 0.05 && _pedalLeftRight  > -0.05)
+        (_cyclicFwdAft    < CENTER_TRIM_VAL && _cyclicFwdAft    > -CENTER_TRIM_VAL) &&
+        (_cyclicLeftRight < CENTER_TRIM_VAL && _cyclicLeftRight > -CENTER_TRIM_VAL) &&
+        (_pedalLeftRight  < CENTER_TRIM_VAL && _pedalLeftRight  > -CENTER_TRIM_VAL)
        ) then {
             _heli setVariable ["fza_sfmplus_flightControlLockOut", false];
        };

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_sfmplus/functions/simpleRotor/fn_simpleRotorMain.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_sfmplus/functions/simpleRotor/fn_simpleRotorMain.sqf
@@ -30,11 +30,15 @@ private _altitude               = _heli getVariable "fza_sfmplus_PA";
 private _temperature            = _heli getVariable "fza_sfmplus_FAT";
 private _dryAirDensity          = _heli getVariable "fza_sfmplus_RHO";
 
-private _attHoldCycPitchOut     = _heli getVariable "fza_sfmplus_attHoldCycPitchOut";
-//if ([_attHoldCycPitchOut] call fza_sfmplus_fnc_isNAN || [_attHoldCycPitchOut] call fza_sfmplus_fnc_isINF) then { _attHoldCycPitchOut = 0.0; };
-private _attHoldCycRollOut      = _heli getVariable "fza_sfmplus_attHoldCycRollOut";
-//if ([_attHoldCycRollOut] call fza_sfmplus_fnc_isNAN || [_attHoldCycRollOut] call fza_sfmplus_fnc_isINF) then { _attHoldCycRollOut = 0.0; };
-private _altHoldCollOut         = _heli getVariable "fza_sfmplus_altHoldCollOut";
+private _attHoldCycPitchOut     = _heli getVariable "fza_sfmplus_fmcAttHoldCycPitchOut";
+private _sasPitchOut            = _heli getVariable "fza_sfmplus_fmcSasPitchOut";
+private _fmcPitchOut            = _attHoldCycPitchOut + _sasPitchOut;
+
+private _attHoldCycRollOut      = _heli getVariable "fza_sfmplus_fmcAttHoldCycRollOut";
+private _sasRollOut             = _heli getVariable "fza_sfmplus_fmcSasRollOut";
+private _fmcRollOut             = _attHoldCycRollOut + _sasRollOut;
+
+private _altHoldCollOut         = _heli getVariable "fza_sfmplus_fmcAltHoldCollOut";
 private _isAutorotating         = _heli getVariable "fza_sfmplus_isAutorotating";
 
 private _rtrPos                 = [0.0, 2.06, 0.70];
@@ -82,7 +86,7 @@ private _velocityThrustExponent = 0.386;
 private _vrsScalarExponent      = 0.3;
 private _rtrTorqueScalar        = 1.0;
 
-private _pitchTorqueScalar      = 3.00;
+private _pitchTorqueScalar      = 2.50;
 private _rollTorqueScalar       = 0.75;
 
 private _baseThrust             = 102306;  //N - max gross weight (kg) * gravity (9.806 m/s)
@@ -283,7 +287,7 @@ private _cyclicFwdAftTrim = 0.0;
 _cyclicFwdAftTrim         = _heli getVariable "fza_ah64_forceTrimPosPitch";
 
 private _pitchTorque      = linearConversion [0.0, 1.0, _inputRPM / _rtrRPMTrimVal, 0.0, 100000 * _pitchTorqueScalar, true];
-private _pitchInput       = ([_cyclicFwdAft, _cyclicFwdAftTrim] call fza_sfmplus_fnc_getInterpInput) + _attHoldCycPitchOut;
+private _pitchInput       = ([_cyclicFwdAft, _cyclicFwdAftTrim] call fza_sfmplus_fnc_getInterpInput) + _fmcPitchOut;
 _pitchInput               = [_pitchInput, -1.0, 1.0] call BIS_fnc_clamp;
 private _torqueX          = _pitchTorque * _pitchInput * _deltaTime; 
 /////////////////////////////////////////////////////////////////////////////////////////////
@@ -293,7 +297,7 @@ private _cyclicLeftRight     = _heli getVariable "fza_sfmplus_cyclicLeftRight";
 private _cyclicLeftRightTrim = 0.0;
 _cyclicLeftRightTrim         = _heli getVariable "fza_ah64_forceTrimPosRoll";
 
-private _rollInput           = ([_cyclicLeftRight, _cyclicLeftRightTrim] call fza_sfmplus_fnc_getInterpInput) + _attHoldCycRollOut;
+private _rollInput           = ([_cyclicLeftRight, _cyclicLeftRightTrim] call fza_sfmplus_fnc_getInterpInput) + _fmcRollOut;
 _rollInput                   = [_rollInput, -1.0, 1.0] call BIS_fnc_clamp;
 private _rollTorque          = linearConversion [0.0, 1.0, _inputRPM / _rtrRPMTrimVal, 0.0, 100000 * _rollTorqueScalar, true];
 private _torqueY             = _rollTorque * _rollInput * _deltaTime; 

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_sfmplus/functions/simpleRotor/fn_simpleRotorMain_v2.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_sfmplus/functions/simpleRotor/fn_simpleRotorMain_v2.sqf
@@ -44,9 +44,15 @@ private _altitude               = _heli getVariable "fza_sfmplus_PA";
 private _temperature            = _heli getVariable "fza_sfmplus_FAT";
 private _dryAirDensity          = _heli getVariable "fza_sfmplus_rho";
 
-private _attHoldCycPitchOut     = _heli getVariable "fza_sfmplus_attHoldCycPitchOut";
-private _attHoldCycRollOut      = _heli getVariable "fza_sfmplus_attHoldCycRollOut";
-private _altHoldCollOut         = _heli getVariable "fza_sfmplus_altHoldCollOut";
+private _attHoldCycPitchOut     = _heli getVariable "fza_sfmplus_fmcAttHoldCycPitchOut";
+private _sasPitchOut            = _heli getVariable "fza_sfmplus_fmcSasPitchOut";
+private _fmcPitchOut            = _attHoldCycPitchOut + _sasPitchOut;
+
+private _attHoldCycRollOut      = _heli getVariable "fza_sfmplus_fmcAttHoldCycRollOut";
+private _sasRollOut             = _heli getVariable "fza_sfmplus_fmcSasRollOut";
+private _fmcRollOut             = _attHoldCycRollOut + _sasRollOut;
+
+private _altHoldCollOut         = _heli getVariable "fza_sfmplus_fmcAltHoldCollOut";
 private _isAutorotating         = _heli getVariable "fza_sfmplus_isAutorotating";
 
 //Get the current collective value
@@ -222,10 +228,10 @@ private _thrustZ             = _axisZ vectorMultiply (_thrust * _deltaTime);
 
 //Pitch torque
 private _cyclicFwdAftTrim    = _heli getVariable "fza_ah64_forceTrimPosPitch";
-private _torqueX             = ((_thrust * ((_heli getVariable "fza_sfmplus_cyclicFwdAft") + _cyclicFwdAftTrim + _attHoldCycPitchOut)) * _pitchTorqueScalar) * _deltaTime;
+private _torqueX             = ((_thrust * ((_heli getVariable "fza_sfmplus_cyclicFwdAft") + _cyclicFwdAftTrim + _fmcPitchOut)) * _pitchTorqueScalar) * _deltaTime;
 //Roll torque
 private _cyclicLeftRightTrim = _heli getVariable "fza_ah64_forceTrimPosRoll";
-private _torqueY             = ((_thrust * ((_heli getVariable "fza_sfmplus_cyclicLeftRight") + _cyclicLeftRightTrim + _attHoldCycRollOut)) * _rollTorqueScalar) * _deltaTime;
+private _torqueY             = ((_thrust * ((_heli getVariable "fza_sfmplus_cyclicLeftRight") + _cyclicLeftRightTrim + _fmcRollOut)) * _rollTorqueScalar) * _deltaTime;
 //Main rotor yaw torque
 private _torqueZ             = (_rtrTorque  * _yawTorqueScalar) * _deltaTime;
 

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_sfmplus/functions/simpleRotor/fn_simpleRotorTail.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_sfmplus/functions/simpleRotor/fn_simpleRotorTail.sqf
@@ -30,7 +30,9 @@ private _altitude               = _heli getVariable "fza_sfmplus_PA";
 private _temperature            = _heli getVariable "fza_sfmplus_FAT";
 private _dryAirDensity          = _heli getVariable "fza_sfmplus_rho";
 
-private _hdgHoldPedalYawOut     = _heli getVariable "fza_sfmplus_hdgHoldPedalYawOut";
+private _hdgHoldPedalYawOut     = _heli getVariable "fza_sfmplus_fmcHdgHoldPedalYawOut";
+private _sasYawOut              = _heli getVariable "fza_sfmplus_fmcSasYawOut";
+private _fmcYawOut              = _hdgHoldPedalYawOut + _sasYawOut;
 
 private _rtrPos                 = [-0.87, -6.98, -0.075];
 private _rtrDesignRPM           = 1403.0;
@@ -71,7 +73,7 @@ private _pedalLeftRight     = _heli getVariable "fza_sfmplus_pedalLeftRight";
 private _pedalLeftRightTrim = 0.0;
 _pedalLeftRightTrim         = _heli getVariable "fza_ah64_forceTrimPosPedal";
 
-private _pedalInput         = ([_pedalLeftRight, _pedalLeftRightTrim] call fza_sfmplus_fnc_getInterpInput) + _hdgHoldPedalYawOut;
+private _pedalInput         = ([_pedalLeftRight, _pedalLeftRightTrim] call fza_sfmplus_fnc_getInterpInput) + _fmcYawOut;
 _pedalInput                 = [_pedalInput, -1.0, 1.0] call BIS_fnc_clamp;
 private _bladePitchInducedThrustScalar = [_bladePitchInducedThrustTable, _pedalInput] call fza_fnc_linearInterp select 1;//linearConversion [_bladePitch_min, _bladePitch_max, _bladePitch_cur, _rtrThrustScalar_min, _rtrThrustScalar_max, true];
 //systemChat format ["_bladePitchInducedThrustScalar = %1 -- _pedalLeftRight = %2", _bladePitchInducedThrustScalar toFixed 3, _pedalLeftRight];

--- a/@AH-64D Apache Longbow/Addons/fza_ah64_sfmplus/headers/core.hpp
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_sfmplus/headers/core.hpp
@@ -50,3 +50,5 @@
 #define HDG_HOLD_BREAKOUT_VALUE       0.05//0.03
 #define VEL_HOLD_BREAKOUT_VALUE       0.10//0.06
 #define ATT_HOLD_BREAKOUT_VALUE       0.20//0.09
+
+#define CENTER_TRIM_VAL               0.05


### PR DESCRIPTION
+ Fix SAS PID error that resulted from improper trimming
+ Add central position trimmer mode to cyclic and pedals
+ Update FMC variable names to enhance debugging