### PR TITLE
Change default collective control to HOTAS

### DIFF
--- a/@AH-64D Apache Longbow/Addons/fza_ah64_controls/XEH_preInit.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_controls/XEH_preInit.sqf
@@ -54,7 +54,7 @@ private _projName = "AH-64D Official Project";
     "LIST",
     ["Collective Control", "HOTAS is for users using a Throttle. Keyboard/Gamepad is for users using a gamepad with buttons or keyboard for collective."],
     [_projName, "Flight model"],
-    [[HOTAS,KEYBOARD],["HOTAS","Keyboard/Gamepad"],1],
+    [[HOTAS,KEYBOARD],["HOTAS","Keyboard/Gamepad"],0],
     2
 ] call CBA_fnc_addSetting;
 


### PR DESCRIPTION
This helicopter and FM were designed for HOTAS users, so makes since that HOTAS setting should be default.